### PR TITLE
docs: development guidelines unified in English and naming conventions updated

### DIFF
--- a/rules/flutter-development-guidelines-cursorrules-prompt-file
+++ b/rules/flutter-development-guidelines-cursorrules-prompt-file
@@ -1,48 +1,48 @@
-### コードスタイルと構造
-- 簡潔で効率的なソースコードを書きます。
-- ソースコードが読みやすく、メンテナンスしやすいソースコードを心がけ、正確な例を示します。
-- コードの重複を避ける：ウィジェットや関数を再利用可能なコンポーネントにモジュール化します。
-- 説明的な変数名を使用する：isLoading、hasErrorのような補助動詞を用いた名前を使います。
+### Code style and structure
+- Write concise and efficient source code.
+- Strive for source code that is easy to read and maintain, and provide accurate examples.
+- Avoid duplication of code: modularise widgets and functions into reusable components.
+- Use descriptive variable names: use names with auxiliary verbs such as isLoading, hasError.
 
-### /lib以下のディレクトリ構造
-- /lib/models/：データモデルや型定義（Model）
-- /lib/viewmodels/：状態管理やビジネスロジック（ViewModel）
-- /lib/views/widgets/：再利用可能なウィジェット（View）
-- /lib/views/screens/：画面ごとのウィジェット（View）
-- /lib/services/：APIコールやデータアクセスのためのサービスクラス
-- /lib/utils/：ヘルパー関数や定数
+### Directory structure under /lib.
+- /lib/models/: data models and type definitions (Models)
+- /lib/viewmodels/: state management and business logic (ViewModel)
+- /lib/views/widgets/: reusable widgets (View)
+- /lib/views/screens/: per-screen widgets (View)
+- /lib/services/: service classes for API calls and data access
+- /lib/utils/: helper functions and constants
 
-### 命名規則
-- ディレクトリとファイル：スネークケースを使用（例：auth_wizard.dart）。
-- 変数名や関数名：キャメルケースを使用（例：lowerCamelCase）。
-- クラス名や型名：パスカルケースを使用（例：UpperCamelCase）。
-- ウィジェット：パスカルケースを使用し、ファイル名と一致させます（例：AuthWizardウィジェットはauth_wizard.dartに置く）。
+### Naming conventions
+- Directories and files: use snakeCase (e.g. auth_wizard.dart).
+- UpperCamelCase: use for class names/enumerations/typedefs/type parameters, etc.
+- LowerCamelCase: used for variables/functions/class members (properties, methods), etc.
+- lowercase_with_underscores (snakeCase): for files/directories/packages/libraries, etc.
 
-### インポート
-- dart:から始まるインポートを最初に配置します（インポートプレフィックスにはlowercase_with_underscoresを使う）。
-- 次にサードパーティのパッケージ（package:）をインポートします。
-- 最後に相対パスやプロジェクト内のファイルをインポートします。
+### Import.
+- Place imports starting with dart: first (use lowercase_with_underscores for the import prefix).
+- Next, import third-party packages (package:).
+- Finally, import relative paths and files in the project.
 
-### 　Dartの使用
-- 型安全を活用する：すべてのコードで静的型付けを使用し、可能な限り型推論を活用します。
+### Using Dart.
+- Take advantage of type safety: use static typing in all code and utilise type inference wherever possible.
 
-### UIとスタイリング
-- Material ウィジェットを使用します。
-- テーマを統一する：ThemeData を使用して一貫性のあるスタイルを適用します
+### UI and styling.
+- Use Material widgets.
+- Unify theming: use ThemeData to apply consistent styles.
 
-### パフォーマンス最適化
-- 状態が不要な場合は StatelessWidget を優先的に使用します。
-- constコンストラクタを活用する：ウィジェットが不変である場合、const を使用してビルドを最適化します。
+### Performance optimisation.
+- Prefer StatelessWidget when state is not required.
+- Make use of const constructors: if widgets are immutable, use const to optimise builds.
 
-### 状態管理
-- riverpodを使い、効率的な状態管理を実装します。
-- ViewModel内で状態を管理し、Viewと連携させます。
+### State management.
+- Use riverpod to implement efficient state management.
+- Manage state within the ViewModel and link it to the View.
 
-### ソフトウェアアーキテクチャ
-MVVM（Model View ViewModel）を使用します。
+### Software architecture
+Use MVVM (Model View ViewModel).
 
-### 主要な規則
-- コードの可読性を向上させるために、行の長さは80文字を超える行を避けます。
-- すべてのフロー制御構造（if、for、whileなど）に中括弧 {} を使用します。
-- コメントアウトは積極的に使い、コードの理解とメンテナンスに役立てます。
-- シングルクォーテーションを使用し、ダブルクォーテーションの使用は避け、一貫性のある文字列リテラルを使用し可読性を高めます。
+### Key rules.
+- To improve code readability, lines should not exceed 80 characters in length.
+- Use braces {} for all flow control structures (if, for, while, etc.).
+- Use comment-outs proactively to help understand and maintain code.
+- Use single quotes, avoid the use of double quotes and use consistent string literals to improve readability.


### PR DESCRIPTION
You have previously MERGE at https://github.com/PatrickJS/awesome-cursorrules/pull/9#event-15082245951, but we have updated the following points and made a PR again.

- Changed the development guidelines for Flutter from Japanese to English (other files are also in English, so we have unified them).
- More detailed description of naming conventions.

Please check it.