### PR TITLE
update instruction for using rules for ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,49 @@
   </a>
 </p>
 
-A curated list of awesome .cursorrules files for enhancing your Cursor AI experience.
+A curated list of awesome Rules for AI files for enhancing your Cursor AI experience.
 
-[Cursor AI](https://cursor.sh/) is an AI-powered code editor. `.cursorrules` files define custom rules for Cursor AI to follow when generating code, allowing you to tailor its behavior to your specific needs and preferences.
+[Cursor AI](https://cursor.sh/) is an AI-powered code editor. Rules for AI define custom rules for Cursor AI to follow when generating code, allowing you to tailor its behavior to your specific needs and preferences.
 
-## Why .cursorrules?
+# Why Rules for AI?
 
-`.cursorrules` is a powerful feature in Cursor AI that allows developers to define project-specific instructions for the AI. Here's why you might want to use it:
+**[Rules for AI](https://docs.cursor.com/context/rules-for-ai)** is a powerful feature in Cursor AI that allows developers to define global or project-specific instructions for the AI. Here's why you might want to use it:
 
-1. **Customized AI Behavior**: `.cursorrules` files help tailor the AI's responses to your project's specific needs, ensuring more relevant and accurate code suggestions.
+1. **Customized AI Behavior**: Rules files help tailor the AI's responses to your project's specific needs, ensuring more relevant and accurate code suggestions.
 
-2. **Consistency**: By defining coding standards and best practices in your `.cursorrules` file, you can ensure that the AI generates code that aligns with your project's style guidelines.
+2. **Consistency**: By defining coding standards and best practices in your rules, you can ensure that the AI generates code that aligns with your project's style guidelines.
 
 3. **Context Awareness**: You can provide the AI with important context about your project, such as commonly used methods, architectural decisions, or specific libraries, leading to more informed code generation.
 
 4. **Improved Productivity**: With well-defined rules, the AI can generate code that requires less manual editing, speeding up your development process.
 
-5. **Team Alignment**: For team projects, a shared `.cursorrules` file ensures that all team members receive consistent AI assistance, promoting cohesion in coding practices.
+5. **Team Alignment**: For team projects, shared rules ensure that all team members receive consistent AI assistance, promoting cohesion in coding practices.
 
 6. **Project-Specific Knowledge**: You can include information about your project's structure, dependencies, or unique requirements, helping the AI to provide more accurate and relevant suggestions.
 
-By creating a `.cursorrules` file in your project's root directory, you can leverage these benefits and enhance your coding experience with Cursor AI.
+## Setting Up Rules in Cursor
+
+### Global Rules
+
+You can set global rules that apply across all projects:
+
+1. Open Cursor Settings
+2. Navigate to General > Rules for AI
+3. Add your custom instructions
+
+### Project Rules (Recommended)
+
+Cursor now offers a more powerful and flexible rules system.
+
+**To Create a Project Rule:**
+
+1. Open the command palette (Cmd + Shift + P)
+2. Select "New Cursor Rule"
+3. Configure your rule with patterns and instructions
+
+### Legacy .cursorrules File
+
+While still supported for backward compatibility, the `.cursorrules` file in the project root is deprecated. We recommend migrating to the new Project Rules system for better flexibility and control over your AI interactions.
 
 ## Contents
 


### PR DESCRIPTION
Since .cursorrules is been deprecated (https://docs.cursor.com/context/rules-for-ai), update the instructions in the to follow the best practice.