### PR TITLE
[Laravel TALL] Fix directory naming convention rule to match Laravel standards

### DIFF
--- a/rules/laravel-tall-stack-best-practices-cursorrules-prom/.cursorrules
+++ b/rules/laravel-tall-stack-best-practices-cursorrules-prom/.cursorrules
@@ -16,7 +16,7 @@ PHP and Laravel Core
 - Use strict typing: declare(strict_types=1);
 - Utilize Laravel's built-in features and helpers when possible.
 - Follow Laravel's directory structure and naming conventions.
-- Use lowercase with dashes for directories (e.g., app/Http/Controllers).
+- Use PascalCase for class-containing directories (e.g., app/Http/Controllers).
 - Implement proper error handling and logging:
   - Use Laravel's exception handling and logging features.
   - Create custom exceptions when necessary.

--- a/rules/laravel-tall-stack-best-practices-cursorrules-prom/php-and-laravel-core-rules.mdc
+++ b/rules/laravel-tall-stack-best-practices-cursorrules-prom/php-and-laravel-core-rules.mdc
@@ -7,7 +7,7 @@ globs: /**/*.php
 - Use strict typing: declare(strict_types=1);
 - Utilize Laravel's built-in features and helpers when possible.
 - Follow Laravel's directory structure and naming conventions.
-- Use lowercase with dashes for directories (e.g., app/Http/Controllers).
+- Use PascalCase for class-containing directories (e.g., app/Http/Controllers).
 - Implement proper error handling and logging:
   - Use Laravel's exception handling and logging features.
   - Create custom exceptions when necessary.


### PR DESCRIPTION
This PR corrects an inconsistency in the Laravel directory naming convention rule.

## Issue
The current rule states "Use lowercase with dashes for directories (e.g., app/Http/Controllers)" but the example provided actually uses PascalCase, not lowercase with dashes.

## Fix
Updated the rule to accurately reflect Laravel's standard naming convention:
- Changed from: "Use lowercase with dashes for directories"
- Changed to: "Use PascalCase for class-containing directories"

## Reference
This change aligns with Laravel's official documentation on directory structure:
https://laravel.com/docs/12.x/structure