### PR TITLE
feat: added an example repos section

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [CursorDirectory](https://cursor.directory/)
 
 ## Repositories with CursorRules
-- [ParadeDB](https://github.com/paradedb/paradedb): a rust-based PostgreSQL fulltext-search extension
+- [ParadeDB](https://github.com/paradedb/paradedb): an Elasticsearch alternative built on Postgres (implemented in Rust).
 
 ## How to Use
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
 
+## Repositories with CursorRules
+- [ParadeDB](https://github.com/paradedb/paradedb): a rust-based PostgreSQL fulltext-search extension
+
 ## How to Use
 
 ### Method One


### PR DESCRIPTION
We've recently added `.cursor/rules` to our project, and we had a hard time finding repos with this new format. I think we should see more projects with the rules baked in them. Hopefully, this new README.md section grows fast.