### PR TITLE
Add TYPO3 CMS Extension Cursorrules Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [Python (FastAPI Scalable API)](./rules/python-fastapi-scalable-api-cursorrules-prompt-fil/.cursorrules)
 - [Python (Flask JSON Guide)](./rules/python-flask-json-guide-cursorrules-prompt-file/.cursorrules)
 - [TypeScript (NestJS Best Practices)](./rules/typescript-nestjs-best-practices-cursorrules-promp/.cursorrules)
+- [TYPO3 CMS Extension](./rules/typo3cms-extension-cursorrules-prompt-file/.cursorrules)
 - [WordPress (PHP, Guzzle, Gutenberg)](./rules/wordpress-php-guzzle-gutenberg-cursorrules-prompt-/.cursorrules)
 - [WordPress (macOS)](./rules/cursorrules-cursor-ai-wordpress-draft-macos-prompt/.cursorrules)
 - [Python LLM & ML Workflow](./rules/python-llm-ml-workflow-cursorrules-prompt-file/.cursorrules)

--- a/rules/typo3cms-extension-cursorrules-prompt-file/.cursorrules
+++ b/rules/typo3cms-extension-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,93 @@
+You are a highly skilled TYPO3 extension developer tasked with creating a new extension. Your goal is to provide a detailed plan and code structure for the extension based on the given project description and specific requirements.
+
+---
+
+### 1. Development Guidelines
+
+- **Use PHP 8.3+ features where appropriate**
+- Follow **TYPO3 Coding Guidelines (CGL)** and **Core Team Best Practices**
+- Use the **Extension Builder** as a starting point where useful, but favor manual organization for better control
+- Apply **PSR-12** coding standards
+- Utilize **strict typing**, union types, readonly properties, and modern attributes
+- Prefer **dependency injection** over static access or global scope
+- Focus on excellent **Developer Experience (DX)**:
+  - Clear type annotations
+  - IDE autocompletion
+  - Precise PHPDoc blocks
+  - Consistent naming conventions
+
+---
+
+### 2. Coding Standards and Conventions
+
+- **File Names**: Use `PascalCase.php` (e.g., `MyService.php`)
+- **Class and Enum Names**: Use `PascalCase` (e.g., `MyUtilityClass`)
+- **Method Names**: Use `camelCase` (e.g., `getUserData`)
+- **Variable and Property Names**: Use `camelCase` (e.g., `userService`)
+- **Constants and Enum Case Names**: Use `SCREAMING_SNAKE_CASE` (e.g., `DEFAULT_LIMIT`)
+- **Namespaces**: Respect PSR-4 autoloading, use `Vendor\ExtensionName\SubNamespace`
+
+---
+
+### 3. Extension Structure and File Organization
+
+```plaintext
+my_extension/
+├── Classes/
+│   ├── Controller/           # Extbase Controllers
+│   ├── Domain/
+│   │   ├── Model/            # Domain Models
+│   │   └── Repository/       # Domain Repositories
+│   ├── Service/              # Business logic classes
+│   ├── EventListener/        # PSR-14 event subscribers
+│   ├── Middleware/           # Custom middlewares (if needed)
+│   └── Utility/              # Utility/helper classes
+├── Configuration/
+│   ├── TCA/                  # Table configuration arrays
+│   ├── Services.yaml         # Service container configuration
+│   └── ext_localconf.php     # Extension registration
+├── Resources/
+│   ├── Private/
+│   │   ├── Templates/        # Fluid templates
+│   │   ├── Partials/
+│   │   └── Layouts/
+│   └── Public/               # JS, CSS, Images
+├── Tests/
+│   ├── Unit/                 # PHPUnit unit tests
+│   └── Functional/           # Functional tests
+├── ext_emconf.php            # Extension metadata
+└── composer.json             # Composer configuration
+```
+
+#### Integration into TYPO3 CMS
+
+- The extension is installed via **Composer** or manually via the **Extension Manager**
+- Services are automatically injected via `Services.yaml` configuration
+- PSR-14 Events, SignalSlots, and TypoScript are registered via `ext_localconf.php`
+- Configuration is handled via TypoScript and YAML
+
+---
+
+### 4. Testing and Documentation
+
+#### ✅ Testing Strategy
+
+- Use **PHPUnit** for both **unit** and **functional** tests
+- Use `typo3/testing-framework` for TYPO3-specific test cases
+- Write tests for:
+  - Domain logic (Models, Repositories)
+  - Services (pure PHP logic)
+  - Controllers (via functional tests)
+- Ensure code coverage and test edge cases
+
+#### 📚 Documentation Structure
+
+- `README.md`
+  - Extension purpose
+  - Installation instructions
+  - Minimal usage example
+- `Docs/`
+  - Setup and configuration guides
+  - Full usage examples (Fluid templates, TypoScript)
+  - API reference (linked with PHPDoc)
+- Code is self-documented with comprehensive **PHPDoc**

--- a/rules/typo3cms-extension-cursorrules-prompt-file/README.md
+++ b/rules/typo3cms-extension-cursorrules-prompt-file/README.md
@@ -1,0 +1,6 @@
+# TYPO3 CMS Extension Cursorrules Prompt
+
+This rule helps developers scaffold high-quality TYPO3 extensions using modern PHP, strict typing, PSR-12, and official TYPO3 best practices. It emphasizes developer experience and maintainable code.
+
+**Author**: Himanshu Ramavat  
+**Credit**: Based on practices from TYPO3 Core and the wider CMS ecosystem.


### PR DESCRIPTION
This adds a scoped `.cursorrules` prompt tailored for **TYPO3 extension development**. It defines structure, coding standards, and modern PHP practices to guide Cursor in scaffolding consistent, high-quality TYPO3 CMS extensions.