### PR TITLE
fix: typo in python dependency rules

### DIFF
--- a/rules/python-312-fastapi-best-practices-cursorrules-prom/python-dependency-management-with-poetry.mdc
+++ b/rules/python-312-fastapi-best-practices-cursorrules-prom/python-dependency-management-with-poetry.mdc
@@ -3,4 +3,4 @@ description: Ensures the project uses Poetry for managing dependencies, promotin
 globs: **/pyproject.toml
 ---
 - Use poetry for dependency management.
-- Use UV when installing depdendencies.
+- Use UV when installing dependencies.


### PR DESCRIPTION
This pull request includes a minor correction to a markdown file. Specifically, it fixes a typo in the description of dependency management practices.

* [`rules/python-312-fastapi-best-practices-cursorrules-prom/python-dependency-management-with-poetry.mdc`](diffhunk://#diff-40b5f8890271150074dd69b64e6f39a1dcb36104fa25961ea7028418ce70eca1L6-R6): Corrected a typo in the description, changing "depdendencies" to "dependencies."- wrong spelling used for dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in the documentation by fixing the spelling of "dependencies."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->