### PR TITLE
fix: minor typo in C++ files

### DIFF
--- a/rules-new/cpp.mdc
+++ b/rules-new/cpp.mdc
@@ -1,6 +1,6 @@
 ---
 description: 
-globs: **/*.c,**/*.cpp,**/*.h,**/*.hpp,**/*.cxx,CMakeLists.txt,*.cmake,conanfile.txt,Makefil,**/*.cc
+globs: **/*.c,**/*.cpp,**/*.h,**/*.hpp,**/*.cxx,CMakeLists.txt,*.cmake,conanfile.txt,Makefile,**/*.cc
 alwaysApply: false
 ---
 # C++ Programming Guidelines

--- a/rules/cpp-programming-guidelines-cursorrules-prompt-file/.cursorrules
+++ b/rules/cpp-programming-guidelines-cursorrules-prompt-file/.cursorrules
@@ -1,6 +1,6 @@
 ---
 description: 
-globs: **/*.c,**/*.cpp,**/*.h,**/*.hpp,**/*.cxx,CMakeLists.txt,*.cmake,conanfile.txt,Makefil,**/*.cc
+globs: **/*.c,**/*.cpp,**/*.h,**/*.hpp,**/*.cxx,CMakeLists.txt,*.cmake,conanfile.txt,Makefile,**/*.cc
 alwaysApply: false
 ---
 # C++ Programming Guidelines


### PR DESCRIPTION
`Makefile` is misspelled as `Makefil` in the `globs` list of `cpp.mdc` and the `.cursorrules` file of `rules/cpp-programming-guidelines-cursorrules-prompt-file`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in file pattern matching to properly include files named "Makefile".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->