### PR TITLE
removed MikroORM from generic nestjs rules

### DIFF
--- a/rules/typescript-nestjs-best-practices-cursorrules-promp/.cursorrules
+++ b/rules/typescript-nestjs-best-practices-cursorrules-promp/.cursorrules
@@ -99,7 +99,6 @@ You are a senior TypeScript programmer with experience in the NestJS framework a
   - DTOs validated with class-validator for inputs.
   - Declare simple types for outputs.
   - A services module with business logic and persistence.
-  - Entities with MikroORM for data persistence.
   - One service per entity.
 - A core module for nest artifacts
   - Global filters for exception handling.

--- a/rules/typescript-nestjs-best-practices-cursorrules-promp/nestjs-general-guidelines.mdc
+++ b/rules/typescript-nestjs-best-practices-cursorrules-promp/nestjs-general-guidelines.mdc
@@ -11,7 +11,6 @@ globs: src/**/*.*
   - DTOs validated with class-validator for inputs.
   - Declare simple types for outputs.
   - A services module with business logic and persistence.
-  - Entities with MikroORM for data persistence.
   - One service per entity.
 - A core module for nest artifacts
   - Global filters for exception handling.

--- a/rules/typescript-nestjs-best-practices-cursorrules-promp/nestjs-module-structure-guidelines.mdc
+++ b/rules/typescript-nestjs-best-practices-cursorrules-promp/nestjs-module-structure-guidelines.mdc
@@ -9,5 +9,4 @@ globs: src/modules/**/*.*
 - DTOs validated with class-validator for inputs.
 - Declare simple types for outputs.
 - A services module with business logic and persistence.
-- Entities with MikroORM for data persistence.
 - One service per entity.


### PR DESCRIPTION
# What I did

- removed MikroORM from generic nestjs rules

# Why
- I think it doesn't make sense for a generic typescript-nestjs rules to mention a specific ORM while there's other popular options as replacement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidelines to remove references to MikroORM entities for data persistence in NestJS best practices documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->