### PR TITLE
Add Cursorrules Collection to Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ## Directories
 
-- [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
+- [CursorList](https://cursorlist.com)
 - [Cursorrules Collection](https://github.com/cursorrulespacks/cursorrules-collection)
 
 ## How to Use

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 - [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
-- [Cursorrules Collection](https://github.com/cursorrulespacks/cursorrules-collection) - 33 tested .cursorrules files across languages (Python, TypeScript, Go, Rust, etc.), frameworks (React, Next.js, Django, FastAPI, etc.), practices (testing, security, accessibility), and tools (Docker, Terraform, CI/CD).
+- [Cursorrules Collection](https://github.com/cursorrulespacks/cursorrules-collection)
 
 ## How to Use
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 - [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
+- [Cursorrules Collection](https://github.com/cursorrulespacks/cursorrules-collection) - 33 tested .cursorrules files across languages (Python, TypeScript, Go, Rust, etc.), frameworks (React, Next.js, Django, FastAPI, etc.), practices (testing, security, accessibility), and tools (Docker, Terraform, CI/CD).
 
 ## How to Use
 


### PR DESCRIPTION
Hi! Adding our open-source [Cursorrules Collection](https://github.com/cursorrulespacks/cursorrules-collection) to the Directories section.

It's a curated, categorized collection of .cursorrules organized by language (Python, TypeScript, Go, etc.), framework (React, Next.js, Django, etc.), and development practice (testing, security, clean code, etc.).

All MIT licensed. Hope it's useful to the community!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new directory entry "Cursorrules Collection" with coverage details.
  * Removed the "CursorDirectory" entry.
  * Retained the "CursorList" entry (ordering adjusted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->