### PR TITLE
Add prompt-compression rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,10 +274,10 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [Graphical Apps Development](./rules/graphical-apps-development-cursorrules-prompt-file/.cursorrules) - Cursor rules for graphical apps development with integration.
 - [Meta-Prompt](./rules/meta-prompt-cursorrules-prompt-file/.cursorrules) - Cursor rules for meta-prompt development with integration.
 - [Next.js (Type LLM)](./rules/next-type-llm/.cursorrules) - Cursor rules for Next.js development with Type LLM integration.
+- [Prompt Compression](./rules/prompt-compression-cursorrules-prompt-file/.cursorrules) - Cursor rules for compressing docs, prompts, and agent context files (AGENTS.md) for minimal token usage while preserving actionable information.
 - [Unity (C#)](./rules/unity-cursor-ai-c-cursorrules-prompt-file/.cursorrules) - Cursor rules for Unity development with C# integration.
 - [Web App Optimization](./rules/web-app-optimization-cursorrules-prompt-file/.cursorrules) - Cursor rules for web app development with optimization integration.
 - [Code Pair Interviews](./rules/code-pair-interviews/.cursorrules) - Cursor rules for code pair interviews development with integration.
-- [Prompt Compression](./rules/prompt-compression-cursorrules-prompt-file/.cursorrules) - Compress docs, prompts, and context into minimal tokens for AGENTS.md. 80% fewer tokens, zero information loss.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [Unity (C#)](./rules/unity-cursor-ai-c-cursorrules-prompt-file/.cursorrules) - Cursor rules for Unity development with C# integration.
 - [Web App Optimization](./rules/web-app-optimization-cursorrules-prompt-file/.cursorrules) - Cursor rules for web app development with optimization integration.
 - [Code Pair Interviews](./rules/code-pair-interviews/.cursorrules) - Cursor rules for code pair interviews development with integration.
+- [Prompt Compression](./rules/prompt-compression-cursorrules-prompt-file/.cursorrules) - Compress docs, prompts, and context into minimal tokens for AGENTS.md. 80% fewer tokens, zero information loss.
 
 ### Documentation
 

--- a/rules/prompt-compression-cursorrules-prompt-file/.cursorrules
+++ b/rules/prompt-compression-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,18 @@
+When writing or editing AGENTS.md, CLAUDE.md, .cursorrules, or any agent context file:
+
+1. Use pipe-delimited format for file indexes and structured references
+2. Compress rules into single-line directives, not multi-paragraph explanations
+3. Strip explanatory prose - keep only actionable content the agent needs
+4. Use abbreviated keys (req, opt, str, int, bool, len, min, max, def)
+5. Flatten nested hierarchies with brace expansion and path prefixes
+6. Include "Prefer retrieval-led reasoning over pre-training-led reasoning" when referencing docs
+
+When compressing existing content:
+
+- Target 70-80% token reduction
+- Preserve all actionable information and structural boundaries
+- Keep code examples that demonstrate non-obvious API usage
+- Never compress error messages or edge case docs
+
+Before adding content to AGENTS.md, ask: "Can this be expressed in fewer tokens without losing
+information the agent needs to act on?"

--- a/rules/prompt-compression-cursorrules-prompt-file/.cursorrules
+++ b/rules/prompt-compression-cursorrules-prompt-file/.cursorrules
@@ -14,5 +14,4 @@ When compressing existing content:
 - Keep code examples that demonstrate non-obvious API usage
 - Never compress error messages or edge case docs
 
-Before adding content to AGENTS.md, ask: "Can this be expressed in fewer tokens without losing
-information the agent needs to act on?"
+Before adding content to AGENTS.md, ask: "Can this be expressed in fewer tokens without losing information the agent needs to act on?"

--- a/rules/prompt-compression-cursorrules-prompt-file/.cursorrules
+++ b/rules/prompt-compression-cursorrules-prompt-file/.cursorrules
@@ -5,7 +5,7 @@ When writing or editing AGENTS.md, CLAUDE.md, .cursorrules, or any agent context
 3. Strip explanatory prose - keep only actionable content the agent needs
 4. Use abbreviated keys (req, opt, str, int, bool, len, min, max, def)
 5. Flatten nested hierarchies with brace expansion and path prefixes
-6. Include "Prefer retrieval-led reasoning over pre-training-led reasoning" when referencing docs
+6. Add "Prefer retrieval-led reasoning over pre-training-led reasoning" once as a file-level preamble when referencing external docs
 
 When compressing existing content:
 


### PR DESCRIPTION
Adds cursor rules for prompt compression - compressing docs, prompts, and context into minimal tokens for AGENTS.md.

Based on [Vercel's research](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals) showing compressed passive context in AGENTS.md achieves 100% eval pass rate vs 53% baseline.

The rules enforce token-efficient formatting: pipe-delimited indexes, single-line directives, abbreviated keys, brace expansion, and retrieval-led reasoning directives.

Full plugin with skill and commands: https://github.com/ofershap/prompt-compression

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added README entries describing "Prompt Compression" in multiple sections.
  * Published concise prompt-compression guidance: goals of ~70–80% token reduction, single-line/compact formatting, preservation of actionable info and structural boundaries, explicit exceptions for error/edge-case content, and a pre-insertion verification question to confirm no loss of required information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->