### PR TITLE
Add conversation-memory rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [ASCII Simulation Game](./rules/ascii-simulation-game-cursorrules-prompt-file/.cursorrules) - Cursor rules for ASCII simulation game development.
 - [Code Guidelines](./rules/code-guidelines-cursorrules-prompt-file/.cursorrules) - Cursor rules for code development with guidelines integration.
 - [Code Style Consistency](./rules/code-style-consistency-cursorrules-prompt-file/.cursorrules) - Cursor rules for code development with style consistency integration.
+- [Conversation Memory](./rules/conversation-memory-cursorrules-prompt-file/.cursorrules) - Cursor rules for searching and recalling past conversation history from Claude Code and Cursor sessions.
 - [DragonRuby Best Practices](./rules/dragonruby-best-practices-cursorrules-prompt-file/.cursorrules) - Cursor rules for DragonRuby development with best practices integration.
 - [Graphical Apps Development](./rules/graphical-apps-development-cursorrules-prompt-file/.cursorrules) - Cursor rules for graphical apps development with integration.
 - [Meta-Prompt](./rules/meta-prompt-cursorrules-prompt-file/.cursorrules) - Cursor rules for meta-prompt development with integration.

--- a/rules/conversation-memory-cursorrules-prompt-file/.cursorrules
+++ b/rules/conversation-memory-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,16 @@
+When a user references a previous conversation, past session, or asks you to remember/recall/find
+something from earlier work:
+
+1. Identify the AI tool's history location:
+   - Claude Code: `~/.claude/history.jsonl` (global index), `~/.claude/projects/*/` (full sessions)
+   - Cursor: `~/.cursor/projects/*/agent-transcripts/` (full transcripts per workspace)
+
+2. Search by keyword first (grep/rg), never read entire history files
+
+3. Extract only key decisions, code changes, and conclusions from past sessions — do not dump raw
+   transcripts into context
+
+4. When multiple sessions match, present them as a numbered list with date, project, and topic so
+   the user can pick the right one
+
+5. After finding relevant history, summarize what was done and what's still open before continuing


### PR DESCRIPTION
Adds conversation-memory rules that teach AI agents to search and recall past conversation history from Claude Code (`~/.claude/history.jsonl`) and Cursor (`~/.cursor/projects/*/agent-transcripts/`).

- Searches by keyword first (grep/rg), never reads entire history files
- Extracts key decisions and conclusions, doesn't dump raw transcripts
- Presents multiple matches as a numbered list for the user to pick

Plugin: https://github.com/ofershap/conversation-memory

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with Conversation Memory feature information
  * Added guidance for accessing and managing past conversation history

<!-- end of auto-generated comment: release notes by coderabbit.ai -->