### PR TITLE
Add cursor-doctor to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Utilities
 
+- [cursor-doctor](https://github.com/nedcodes-ok/cursor-doctor) - Diagnose and auto-fix your Cursor setup. Checks for broken frontmatter, rule conflicts, redundant rules, token budget issues, and missing coverage. `npx cursor-doctor scan` gives a health grade (A-F). Zero dependencies.
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
 
 ## Directories

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Utilities
 
-- [cursor-doctor](https://github.com/nedcodes-ok/cursor-doctor) - Diagnose and auto-fix your Cursor setup. Checks for broken frontmatter, rule conflicts, redundant rules, token budget issues, and missing coverage. `npx cursor-doctor scan` gives a health grade (A-F). Zero dependencies.
+- [Cursor Doctor](https://github.com/nedcodes-ok/cursor-doctor) - Diagnose and auto-fix your Cursor setup. Checks for broken frontmatter, rule conflicts, redundant rules, token budget issues, and missing coverage. `npx cursor-doctor scan` gives a health grade (A-F). Zero dependencies.
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
 
 ## Directories


### PR DESCRIPTION
Adds [cursor-doctor](https://github.com/nedcodes-ok/cursor-doctor) to the Utilities section.

cursor-doctor is a zero-dependency CLI that diagnoses Cursor AI setups. `npx cursor-doctor scan` checks for broken frontmatter, rule conflicts, redundant rules, token budget waste, and missing coverage, then gives a health grade (A-F).

Successor to cursor-lint (~1,800 npm downloads).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the Cursor Doctor utility, including a description and usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->