### PR TITLE
Add rule-porter to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 ### Utilities
 
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
+- [rule-porter](https://github.com/nedcodes-ok/rule-porter) - A zero-dependency CLI that converts Cursor `.mdc` rules to AGENTS.md, CLAUDE.md, Copilot, and Windsurf formats (and back). Bidirectional conversion with lossy-conversion warnings. `npx rule-porter --to agents-md`
 
 ## Directories
 


### PR DESCRIPTION
Adds [rule-porter](https://github.com/nedcodes-ok/rule-porter) to the Utilities section.

rule-porter is a zero-dependency CLI that converts Cursor `.mdc` rules to AGENTS.md, CLAUDE.md, Copilot, and Windsurf formats — and back. It handles edge cases like broken frontmatter and non-English content, and warns about lossy conversions (glob patterns, alwaysApply flags) that don't have equivalents in flat markdown formats.

```bash
npx rule-porter --to agents-md
npx rule-porter --from agents-md --to cursor
```

Published on npm: https://www.npmjs.com/package/rule-porter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with new information about the rule-porter utility under the Utilities section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->