### PR TITLE
Add README best practices rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [Graphical Apps Development](./rules/graphical-apps-development-cursorrules-prompt-file/.cursorrules) - Cursor rules for graphical apps development with integration.
 - [Meta-Prompt](./rules/meta-prompt-cursorrules-prompt-file/.cursorrules) - Cursor rules for meta-prompt development with integration.
 - [Next.js (Type LLM)](./rules/next-type-llm/.cursorrules) - Cursor rules for Next.js development with Type LLM integration.
+- [README Best Practices](./rules/readme-best-practices-cursorrules-prompt-file/.cursorrules) - Cursor rules for README documentation with best practices integration.
 - [Unity (C#)](./rules/unity-cursor-ai-c-cursorrules-prompt-file/.cursorrules) - Cursor rules for Unity development with C# integration.
 - [Web App Optimization](./rules/web-app-optimization-cursorrules-prompt-file/.cursorrules) - Cursor rules for web app development with optimization integration.
 - [Code Pair Interviews](./rules/code-pair-interviews/.cursorrules) - Cursor rules for code pair interviews development with integration.

--- a/rules/readme-best-practices-cursorrules-prompt-file/.cursorrules
+++ b/rules/readme-best-practices-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,11 @@
+Write READMEs like landing pages, not API docs. The reader decides in 3-5 seconds.
+
+Start with a bold one-liner saying what it does and why someone should care. Not "A tool that..." - a punchline.
+Put a working code example in the first 5 lines. Show the value prop immediately.
+Use feature tables (two columns) instead of **Feature:** bullet lists. Tables scan faster.
+Quick Start must be copy-paste ready. No $ prefix on bash commands. Zero to running in 30 seconds.
+Vary sentence lengths and structure. Mix one-liners with short paragraphs and tables. Not walls of same-length bullets.
+Never use "seamless", "robust", "comprehensive", "cutting-edge", or other AI marketing words.
+Never open with "In today's..." or close with "Happy coding!"
+Check that referenced assets (demo.gif, screenshots) actually exist on disk before adding image links.
+Author section should include a visual card or badge, not just plain text "Made by username".


### PR DESCRIPTION
Adds a cursor rule for writing better READMEs. Agents default to dry, template-style docs with generic openings and bold-label bullet lists. This rule teaches them to write READMEs like landing pages - punchline first, feature tables, copy-paste install blocks.

Source: https://github.com/ofershap/readme-best-practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README best practices guide with recommendations for documentation structure, formatting standards, content organization, and effective writing techniques to improve readability and user experience.

* **Chores**
  * Updated documentation references to include new best practices standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->