### PR TITLE
Add Skill Dock to Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,9 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ## Directories
 
-- [CursorList](https://cursorlist.com)
-- [Skill Dock](https://marketplace.visualstudio.com/items?itemName=skill-dock.skill-dock) - VS Code extension to manage, browse, and import agent skills across Cursor and 20+ AI tools.
 - [CursorDirectory](https://cursor.directory/)
+- [CursorList](https://cursorlist.com)
+- [Skill Dock](https://marketplace.visualstudio.com/items?itemName=skill-dock.skill-dock)
 
 ## How to Use
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 ## Directories
 
 - [CursorList](https://cursorlist.com)
+- [Skill Dock](https://marketplace.visualstudio.com/items?itemName=skill-dock.skill-dock) - VS Code extension to manage, browse, and import agent skills across Cursor and 20+ AI tools.
 - [CursorDirectory](https://cursor.directory/)
 
 ## How to Use


### PR DESCRIPTION
Adds [Skill Dock](https://marketplace.visualstudio.com/items?itemName=skill-dock.skill-dock) to the Directories section.

Skill Dock is a VS Code extension for managing agent skills locally. It supports importing skills into Cursor (and 20+ other AI tools) in the correct format, with a built-in marketplace and skills.sh integration.

- [GitHub](https://github.com/yen0304/Skill-Dock)
- [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=skill-dock.skill-dock)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  - Added a "Skill Dock" link in the Directories section of the README.
  - Removed the "CursorDirectory" link and ensured "CursorList" remains listed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->