### PR TITLE
Add Survivor Forge to Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 - [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
+- [Survivor Forge Cursor Rules](https://github.com/survivorforge/cursor-rules) - A collection of .cursorrules files covering 16 frameworks including React, Next.js, Python, Go, Rust, Flutter, and more.
 
 ## How to Use
 

--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ## Directories
 
-- [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
+- [CursorList](https://cursorlist.com)
 - [Survivor Forge Cursor Rules](https://github.com/survivorforge/cursor-rules) - A collection of .cursorrules files covering 16 frameworks including React, Next.js, Python, Go, Rust, Flutter, and more.
 
 ## How to Use


### PR DESCRIPTION
Adds [Survivor Forge Cursor Rules](https://github.com/survivorforge/cursor-rules) to the Directories section.

The repo contains .cursorrules files for 16 frameworks/languages: React, Next.js, Python (Django, FastAPI), Go, Rust, Flutter, SvelteKit, Node.js/Express, TypeScript, Tailwind CSS, Supabase, Docker/DevOps, AWS Serverless, Chrome Extensions, and LangChain.

Each file follows the same format used in this repo — practical rules covering code style, architecture patterns, error handling, and testing conventions for each framework.

Happy to adjust the entry wording if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README directories: removed the CursorDirectory entry while keeping CursorList.
  * Added a new reference link for "Survivor Forge Cursor Rules" under Directories.
  * Minor tidy-up to directory listings and links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->