### PR TITLE
Add Cloudflare Email to Telegram cursorrules

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Hosting and Deployments
 
+- [Cloudflare Email to Telegram](./rules/cloudflare-email-telegram-cursorrules-prompt-file/.cursorrules) - Cursor rules for setting up email-to-Telegram forwarding via Cloudflare Email Routing and Workers using the mail2tg CLI.
 - [Netlify](./rules/netlify-official-cursorrules-prompt-file/.cursorrules) - Cursor rules for Netlify development with official integration.
 
 ### Build Tools and Development

--- a/rules/cloudflare-email-telegram-cursorrules-prompt-file/.cursorrules
+++ b/rules/cloudflare-email-telegram-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,64 @@
+You are an expert at setting up email-to-Telegram forwarding using Cloudflare Email Routing and Workers.
+
+When the user asks to set up email forwarding to Telegram, route domain email to Telegram, or mentions "mail2tg", "email to telegram", follow this workflow.
+
+## Tool
+
+Use the `mail2tg` CLI published on npm: https://www.npmjs.com/package/mail2tg
+Source: https://github.com/shatzibitten/mail2tg
+
+## Prerequisites
+
+1. Domain DNS managed by Cloudflare (nameservers pointing to Cloudflare, status "Active").
+2. Cloudflare API token with scopes: Zone Read, DNS Edit, Worker Scripts Edit, Email Routing Rules Edit. Create at dash.cloudflare.com/profile/api-tokens → "Create Custom Token".
+3. Telegram bot created via @BotFather, token copied. User has sent /start to the bot.
+4. Node.js >= 20.
+
+## Non-interactive workflow (recommended)
+
+```bash
+export CLOUDFLARE_API_TOKEN="<token>"
+export TELEGRAM_BOT_TOKEN="<bot-token>"
+
+MAIL2TG_DOMAIN=example.com \
+MAIL2TG_MAILBOX=info@example.com \
+npx mail2tg init --non-interactive --json
+
+npx mail2tg plan --json --non-interactive
+npx mail2tg apply --json --non-interactive
+npx mail2tg doctor --json --non-interactive
+```
+
+## Interactive workflow
+
+```bash
+npx mail2tg init
+export CLOUDFLARE_API_TOKEN="<token>"
+export TELEGRAM_BOT_TOKEN="<bot-token>"
+npx mail2tg plan
+npx mail2tg apply
+npx mail2tg doctor
+```
+
+## What it does
+
+- Deploys a Cloudflare Worker that parses incoming emails (MIME) and forwards headers, body, and attachments (up to 50 MB) to a Telegram chat via Bot API.
+- Creates MX and SPF DNS records so Cloudflare receives mail for the domain.
+- Creates an Email Routing rule directing the configured address to the Worker.
+- Sets Worker secrets (TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID).
+
+After apply, nothing runs locally. Everything is serverless on Cloudflare's edge. Free tier covers 100K emails/day.
+
+## Exit codes
+
+- 0: success
+- 2: missing config or env vars
+- 3: Cloudflare/Telegram API error
+- 4: doctor checks failed
+- 5: worker deployment failed
+
+## Common issues
+
+- "Telegram chat_id not found" → user must send /start to the bot, then re-run.
+- "Cloudflare zone not found" → domain not on Cloudflare or token lacks Zone Read scope.
+- "Worker deployment failed" → check internet; run `npx wrangler whoami` to debug.

--- a/rules/cloudflare-email-telegram-cursorrules-prompt-file/README.md
+++ b/rules/cloudflare-email-telegram-cursorrules-prompt-file/README.md
@@ -1,0 +1,11 @@
+# Cloudflare Email to Telegram
+
+Cursor rules for setting up email-to-Telegram forwarding using Cloudflare Email Routing, Workers, and the [mail2tg](https://github.com/shatzibitten/mail2tg) CLI.
+
+## What it does
+
+Guides the AI agent through configuring `address@yourdomain.com` → Telegram forwarding in one shot using the `mail2tg` npm package. After setup, everything runs serverlessly on Cloudflare — no local service needed.
+
+## Credits
+
+- [mail2tg](https://github.com/shatzibitten/mail2tg) by [shatzibitten](https://github.com/shatzibitten)


### PR DESCRIPTION
## Summary

- Adds cursor rules for setting up **email-to-Telegram forwarding** via Cloudflare Email Routing and Workers using the [`mail2tg`](https://github.com/shatzibitten/mail2tg) CLI.
- Placed in **Hosting and Deployments** category (alongside Netlify).

## What the rules do

Guide the AI agent through the full setup workflow:
1. Deploy a Cloudflare Worker that parses incoming emails and forwards them (with attachments up to 50 MB) to Telegram.
2. Create MX + SPF DNS records.
3. Configure Email Routing rules.
4. Set Worker secrets.

After setup, everything runs serverlessly on Cloudflare's free tier — no local service needed.

## Files added

- `rules/cloudflare-email-telegram-cursorrules-prompt-file/.cursorrules` — the rules file
- `rules/cloudflare-email-telegram-cursorrules-prompt-file/README.md` — credits and description
- Updated main `README.md` with link in Hosting and Deployments section


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Email to Telegram email forwarding capability to supported solutions.

* **Documentation**
  * Added comprehensive configuration guides for email-to-Telegram forwarding via Cloudflare Email Routing and Workers.
  * Removed Netlify from the Hosting and Deployments reference list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->