### PR TITLE
Add AgenTopology — generates .cursor/rules from declarative agent definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Utilities
 
+- [AgenTopology](https://github.com/agentopology/agentopology) - A declarative language and CLI for defining multi-agent teams in `.at` files and scaffolding `.cursor/rules/*.mdc` files automatically. Define your agents, tools, and coordination once, then generate cursor rules (and configs for 5 other platforms) with a single command.
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
 
 ## Directories


### PR DESCRIPTION
## Summary

- Adds [AgenTopology](https://github.com/agentopology/agentopology) to the **Utilities** section
- AgenTopology is a declarative language and CLI that lets you define multi-agent teams in `.at` files, then scaffold `.cursor/rules/*.mdc` files (and configs for 5 other platforms) with a single command
- Placed alphabetically before "Cursor Watchful Headers" in Utilities, matching the existing entry format

## Why it belongs here

AgenTopology directly generates Cursor rule files from a higher-level declarative definition. Instead of hand-writing `.cursorrules` or `.mdc` files, users define their agent topology once and run `npx agentopology sync cursor` to produce the cursor rules automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AgenTopology, a declarative multi-agent language/CLI tool, to the Utilities section for automatic Cursor rule/config file generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->