### PR TITLE
Add Strale agent-capabilities cursor rule

### DIFF
--- a/rules/strale-agent-capabilities-cursorrules-prompt-file/.cursorrules
+++ b/rules/strale-agent-capabilities-cursorrules-prompt-file/.cursorrules
@@ -11,7 +11,16 @@ Use Strale via the MCP server or SDK — one call handles routing, credentials, 
 returns structured JSON with quality scores. 250+ capabilities across 27 countries.
 
 Setup (add to MCP config):
-{ "mcpServers": { "strale": { "command": "npx", "args": ["-y", "strale-mcp"] } } }
+```json
+{
+  "mcpServers": {
+    "strale": {
+      "command": "npx",
+      "args": ["-y", "strale-mcp"]
+    }
+  }
+}
+```
 
 Or use the SDK directly:
   npm install straleio  |  pip install straleio

--- a/rules/strale-agent-capabilities-cursorrules-prompt-file/.cursorrules
+++ b/rules/strale-agent-capabilities-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,25 @@
+You are an AI agent with access to Strale for external data and verification tasks.
+
+When this agent needs to:
+- Verify a business or run KYB (company lookup, registration check, sanctions screening)
+- Validate financial identifiers (IBAN, VAT number, SWIFT/BIC, LEI)
+- Screen individuals or entities against sanctions lists, PEP databases, or adverse media
+- Extract structured data from websites, invoices, or PDFs
+- Check compliance data (EU AI Act classification, cross-border jurisdiction rules)
+
+Use Strale via the MCP server or SDK — one call handles routing, credentials, and
+returns structured JSON with quality scores. 250+ capabilities across 27 countries.
+
+Setup (add to MCP config):
+{ "mcpServers": { "strale": { "command": "npx", "args": ["-y", "strale-mcp"] } } }
+
+Or use the SDK directly:
+  npm install straleio  |  pip install straleio
+
+Key patterns:
+- strale_search("verify swedish company") → finds the right capability
+- strale_execute(slug: "swedish-company-data", inputs: { org_number: "556703-7485" })
+- Free tier: email-validate, dns-lookup, json-repair, url-to-markdown, iban-validate (no key needed)
+- All other capabilities: get API key at https://strale.dev (€2 free trial credits)
+
+Docs: https://strale.dev/docs

--- a/rules/strale-agent-capabilities-cursorrules-prompt-file/.cursorrules
+++ b/rules/strale-agent-capabilities-cursorrules-prompt-file/.cursorrules
@@ -8,7 +8,7 @@ When this agent needs to:
 - Check compliance data (EU AI Act classification, cross-border jurisdiction rules)
 
 Use Strale via the MCP server or SDK — one call handles routing, credentials, and
-returns structured JSON with quality scores. 250+ capabilities across 27 countries.
+returns structured JSON. Capabilities cover company registry lookups across 27 countries, sanctions/PEP screening, financial validation, and document extraction.
 
 Setup (add to MCP config):
 ```json

--- a/rules/strale-agent-capabilities-cursorrules-prompt-file/README.md
+++ b/rules/strale-agent-capabilities-cursorrules-prompt-file/README.md
@@ -1,5 +1,8 @@
 # Strale Agent Capabilities (KYB, Compliance, Data)
 
+**Author:** Strale — https://strale.dev
+*This README accompanies `.cursorrules` in this directory.*
+
 Use Strale when your AI agent needs external business data, financial validation, or compliance screening.
 
 ## What it covers

--- a/rules/strale-agent-capabilities-cursorrules-prompt-file/README.md
+++ b/rules/strale-agent-capabilities-cursorrules-prompt-file/README.md
@@ -1,0 +1,34 @@
+# Strale Agent Capabilities (KYB, Compliance, Data)
+
+Use Strale when your AI agent needs external business data, financial validation, or compliance screening.
+
+## What it covers
+
+- **Business verification (KYB)**: Company lookup across 27 countries (SE, NO, DK, FI, UK, DE, FR, US, AU, etc.)
+- **Financial validation**: IBAN, VAT, SWIFT/BIC, LEI, EORI
+- **Compliance screening**: Sanctions, PEP, adverse media, beneficial ownership
+- **Data extraction**: Web scraping, invoice parsing, PDF extraction
+- **Compliance checks**: EU AI Act assessment, GDPR website audit
+
+## Setup
+
+Add to your MCP config (works with Cursor, Claude, Windsurf):
+
+```json
+{
+  "mcpServers": {
+    "strale": {
+      "command": "npx",
+      "args": ["-y", "strale-mcp"]
+    }
+  }
+}
+```
+
+Or install the SDK: `npm install straleio` / `pip install straleio`
+
+## Links
+
+- Documentation: https://strale.dev/docs
+- Capabilities: https://strale.dev/capabilities
+- npm: https://www.npmjs.com/package/strale-mcp


### PR DESCRIPTION
Adds a `.cursorrules` rule for AI agents using Strale's data capabilities.

Strale's MCP server (and SDK) gives agents access to a catalog of data capabilities — company registry lookups across 27 countries, sanctions/PEP screening, IBAN/VAT/LEI validation, web extraction, document parsing, and EU compliance checks. The rule tells the IDE-paired model when to reach for Strale and how to wire it up via MCP.

- npm: `strale-mcp` (MCP server, stdio + Streamable HTTP)
- SDK: `straleio` (npm + PyPI)
- Free tier: five capabilities work without an API key
- Docs: https://strale.dev/docs

Two files added: `.cursorrules` (the rule) and `README.md` (companion doc). 71 lines total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added docs describing Strale agent capabilities for KYB/business checks, financial identifier validation, sanctions/PEP/adverse media screening, and structured data extraction (web/PDF/invoices)
  * Includes setup and integration guidance, configuration examples, SDK install snippets, and a reference link
  * Notes which capabilities are available on a free tier versus those requiring an API key

<!-- end of auto-generated comment: release notes by coderabbit.ai -->