### PR TITLE
Add AKF — The AI Native File Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Utilities
 
+- [AKF — The AI Native File Format](rules/akf-ai-native-file-format-cursorrules-prompt-file/.cursorrules) - EXIF for AI. Stamps every AI-generated file with trust scores, source provenance, and compliance metadata. Embeds natively into 20+ formats (DOCX, PDF, images, code). Includes compliance auditing for EU AI Act, SOX, HIPAA.
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
 
 ## Directories

--- a/rules/akf-ai-native-file-format-cursorrules-prompt-file/.cursorrules
+++ b/rules/akf-ai-native-file-format-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,53 @@
+# AKF — The AI Native File Format
+# Stamps every AI-generated file with trust scores, provenance, and compliance metadata.
+# https://akf.dev | https://github.com/HMAKT99/AKF
+
+## After creating or modifying files
+
+When you create or modify a file, stamp it with AKF trust metadata:
+
+```bash
+akf stamp <file> --agent cursor --evidence "<what you did>"
+```
+
+Evidence examples:
+- "generated from user prompt"
+- "refactored existing code"
+- "tests pass"
+- "docs reviewed"
+- "generated from spec"
+
+## After completing a task
+
+```bash
+akf stamp <file> --agent cursor --evidence "<summary of what was done>"
+```
+
+## When working with existing AKF-stamped files
+
+Always check existing trust metadata before modifying:
+
+```bash
+akf read <file>          # Check trust metadata
+akf inspect <file>       # See detailed trust scores
+```
+
+## Classification rules
+
+- Use `--label confidential` for files in `*/finance/*`, `*/secret/*`, `*/internal/*`
+- Use `--label public` for README, docs, examples
+- Default is `internal`
+
+## Compliance check
+
+```bash
+akf audit <file> --regulation eu_ai_act    # EU AI Act Article 50
+akf audit <file> --regulation hipaa         # HIPAA
+akf audit <file> --regulation sox           # SOX
+```
+
+## Install
+
+```bash
+pip install akf
+```

--- a/rules/akf-ai-native-file-format-cursorrules-prompt-file/.cursorrules
+++ b/rules/akf-ai-native-file-format-cursorrules-prompt-file/.cursorrules
@@ -2,52 +2,85 @@
 # Stamps every AI-generated file with trust scores, provenance, and compliance metadata.
 # https://akf.dev | https://github.com/HMAKT99/AKF
 
-## After creating or modifying files
+## How to use
 
-When you create or modify a file, stamp it with AKF trust metadata:
+AKF commands are run by the developer in a terminal (or via pre-commit hooks / CI).
+Cursor AI should suggest these commands in responses when creating or modifying files.
+
+### After creating or modifying files
+
+Run manually in terminal, or add to a Git pre-commit hook for automation:
 
 ```bash
+# Manual — run after Cursor generates a file
 akf stamp <file> --agent cursor --evidence "<what you did>"
+
+# Examples
+akf stamp src/api.py --agent cursor --evidence "generated REST endpoint from spec"
+akf stamp docs/guide.md --agent cursor --evidence "docs reviewed and updated"
+akf stamp tests/test_auth.py --agent cursor --evidence "tests pass"
 ```
 
-Evidence examples:
-- "generated from user prompt"
-- "refactored existing code"
-- "tests pass"
-- "docs reviewed"
-- "generated from spec"
-
-## After completing a task
+### Automation options
 
 ```bash
-akf stamp <file> --agent cursor --evidence "<summary of what was done>"
+# Option 1: Git pre-commit hook (runs automatically on every commit)
+# Add to .pre-commit-config.yaml:
+#   repos:
+#     - repo: https://github.com/HMAKT99/akf-pre-commit
+#       rev: v1
+#       hooks:
+#         - id: akf-stamp
+
+# Option 2: CI/CD — use the GitHub Action
+# Add to .github/workflows/:
+#   - uses: HMAKT99/akf-action@v1
 ```
 
-## When working with existing AKF-stamped files
+### Before modifying existing files
 
-Always check existing trust metadata before modifying:
+Check existing trust metadata to understand provenance context:
 
 ```bash
-akf read <file>          # Check trust metadata
-akf inspect <file>       # See detailed trust scores
+akf read <file>          # Show trust metadata summary
+akf inspect <file>       # Show detailed trust scores and sources
 ```
 
-## Classification rules
+### Classification rules
 
-- Use `--label confidential` for files in `*/finance/*`, `*/secret/*`, `*/internal/*`
-- Use `--label public` for README, docs, examples
-- Default is `internal`
+Labels are based on POSIX-style shell glob patterns matching file paths.
+First matching rule wins; default is `internal` if no rule matches.
 
-## Compliance check
+| Pattern | Label | Example match |
+|---------|-------|--------------|
+| `*/finance/*` | confidential | `services/finance/q3-report.pdf` |
+| `*/secret/*` | confidential | `config/secret/keys.yaml` |
+| `*/internal/*` | confidential | `docs/internal/roadmap.md` |
+| README*, docs/*, examples/* | public | `docs/getting-started.md` |
+| Everything else | internal | `src/api.py` |
 
 ```bash
-akf audit <file> --regulation eu_ai_act    # EU AI Act Article 50
-akf audit <file> --regulation hipaa         # HIPAA
-akf audit <file> --regulation sox           # SOX
+akf stamp <file> --label confidential  # Explicit override
+akf stamp <file> --label public        # For open-source docs
 ```
+
+### Compliance auditing
+
+Check files against regulatory requirements (requires `pip install akf`):
+
+```bash
+akf audit <file> --regulation eu_ai_act    # EU AI Act Article 50 (Aug 2, 2026)
+akf audit <file> --regulation hipaa         # HIPAA (healthcare data)
+akf audit <file> --regulation sox           # SOX (financial reporting)
+```
+
+These commands are part of the `akf` CLI, documented at https://akf.dev.
 
 ## Install
 
 ```bash
 pip install akf
 ```
+
+The `akf` package is available on GitHub: https://github.com/HMAKT99/AKF
+Documentation: https://akf.dev


### PR DESCRIPTION
Adds `.cursorrules` for [AKF (Agent Knowledge Format)](https://github.com/HMAKT99/AKF) — the AI native file format.

**What it does:** Instructs Cursor to stamp every AI-generated file with trust metadata — trust scores, source provenance, and compliance data. Think EXIF for AI.

**Why it's useful for Cursor users:**
- Every file Cursor creates/modifies gets stamped with provenance
- Trust metadata embeds natively into 20+ formats (no sidecars)
- One-command compliance audit (EU AI Act, SOX, HIPAA)
- `akf read <file>` before modifying shows existing trust context

**Install:** `pip install akf`
**Docs:** https://akf.dev
**Demo:** https://huggingface.co/spaces/HANAKT19/akf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the AI Native File Format (AKF): how to embed trust/provenance/compliance metadata, CLI examples for stamping and inspection, pre-edit verification, classification/labeling rules and overrides, compliance audit commands, installation instructions, and guidance for automating workflows (pre-commit/hooks and CI).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->