### PR TITLE
Add ai-coding-guide to Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,9 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ## Directories
 
-- [ai-coding-guide](https://github.com/jnMetaCode/ai-coding-guide) - Best practices for 8 AI coding tools (Claude Code, Cursor, Copilot, Windsurf, Gemini CLI, Kiro, Aider, Trae) with copy-paste config templates.
-- [CursorList](https://cursorlist.com)
+- [ai-coding-guide](https://github.com/jnMetaCode/ai-coding-guide) - Best practices for 9 AI coding tools (Claude Code, Cursor, Copilot, Windsurf, Gemini CLI, Kiro, Aider, Trae, OpenClaw) with copy-paste config templates.
 - [CursorDirectory](https://cursor.directory/)
+- [CursorList](https://cursorlist.com)
 
 ## How to Use
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ## Directories
 
+- [ai-coding-guide](https://github.com/jnMetaCode/ai-coding-guide) - Best practices for 8 AI coding tools (Claude Code, Cursor, Copilot, Windsurf, Gemini CLI, Kiro, Aider, Trae) with copy-paste config templates.
 - [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
 


### PR DESCRIPTION
## What

Add [ai-coding-guide](https://github.com/jnMetaCode/ai-coding-guide) to the Directories section.

## Why

A Chinese-language best practices guide covering 8 AI coding tools — including Cursor — with copy-paste config templates (.cursorrules, .windsurfrules, CLAUDE.md, etc.) and multi-tool collaboration workflows.

Covers: Claude Code, Cursor, Copilot, Windsurf, Gemini CLI, Kiro, Aider, Trae.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "ai-coding-guide" directory listing that documents best practices for 9 AI coding tools and includes copy-paste configuration templates for quick setup.
  * Reordered the directories list: moved the "CursorList" entry from the top to the bottom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->