### PR TITLE
Add OSOP session logging rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 ### Utilities
 
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
+- [OSOP Session Logging](./rules/osop-session-logging-cursorrules-prompt-file/.cursorrules) - Cursor rules for recording AI coding sessions as structured `.osop` + `.osoplog.yaml` workflow logs using the [OSOP protocol](https://github.com/Archie0125/osop-spec). View logs at [osop-editor.vercel.app](https://osop-editor.vercel.app).
 
 ## Directories
 

--- a/rules-new/osop-session-logging.mdc
+++ b/rules-new/osop-session-logging.mdc
@@ -1,5 +1,8 @@
-<!-- trigger: always -->
-
+---
+description: OSOP session logging - record AI coding sessions as structured .osop + .osoplog.yaml files for reproducibility and observability. Apply after completing multi-step tasks.
+globs:
+alwaysApply: true
+---
 # OSOP Session Logging
 
 After completing a significant task (multi-step work, not trivial one-liners), produce an **OSOP session log** so there is a structured, portable record of what was done.

--- a/rules-new/osop-session-logging.mdc
+++ b/rules-new/osop-session-logging.mdc
@@ -19,7 +19,7 @@ id: "session-<short-description>"
 name: "<What you did>"
 description: "<1-2 sentence summary>"
 version: "1.0.0"
-tags: [windsurf, <relevant-tags>]
+tags: [cursor, <relevant-tags>]
 
 nodes:
   - id: "<step-id>"
@@ -55,7 +55,7 @@ ended_at: "<ISO timestamp>"
 duration_ms: <total ms>
 
 runtime:
-  agent: "windsurf"
+  agent: "cursor"
   model: "<model>"
 
 node_records:

--- a/rules/osop-session-logging-cursorrules-prompt-file/.cursorrules
+++ b/rules/osop-session-logging-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,109 @@
+---
+description: OSOP session logging — creates structured .osop + .osoplog.yaml workflow records after multi-step tasks
+globs:
+alwaysApply: true
+---
+
+# OSOP Session Logging
+
+After completing a significant task (multi-step work, not trivial one-liners), produce an **OSOP session log** so there is a structured, portable record of what was done.
+
+1. **Create a `.osop` file** describing the workflow you followed
+2. **Create a `.osoplog.yaml` file** recording what you actually did
+3. **Tell the user** to open both files at https://osop-editor.vercel.app
+
+## .osop format (workflow definition)
+
+```yaml
+osop_version: "1.0"
+id: "session-<short-description>"
+name: "<What you did>"
+description: "<1-2 sentence summary>"
+version: "1.0.0"
+tags: [cursor, <relevant-tags>]
+
+nodes:
+  - id: "<step-id>"
+    type: "<node-type>"   # human, agent, mcp, cli, api, cicd, git, db, docker, infra, system, event, gateway, data
+    subtype: "<subtype>"  # Optional: llm, explore, plan, worker, tool, test, commit, rest, script
+    name: "<Step Name>"
+    description: "<What this step does>"
+    security:
+      risk_level: "<low|medium|high|critical>"
+
+edges:
+  - from: "<step-a>"
+    to: "<step-b>"
+    mode: "sequential"    # sequential, parallel, conditional, fallback, error, spawn, loop, timeout
+```
+
+## .osoplog.yaml format (execution record)
+
+```yaml
+osoplog_version: "1.0"
+run_id: "<uuid>"
+workflow_id: "<matches .osop id>"
+mode: "live"
+status: "COMPLETED"
+
+trigger:
+  type: "manual"
+  actor: "user"
+  timestamp: "<ISO timestamp>"
+
+started_at: "<ISO timestamp>"
+ended_at: "<ISO timestamp>"
+duration_ms: <total ms>
+
+runtime:
+  agent: "cursor"
+  model: "<model>"
+
+node_records:
+  - node_id: "<step-id>"
+    node_type: "<type>"
+    attempt: 1
+    status: "COMPLETED"
+    started_at: "<ISO>"
+    ended_at: "<ISO>"
+    duration_ms: <ms>
+    outputs:
+      <what you produced>
+    tools_used:
+      - { tool: "<tool-name>", calls: <n> }
+    reasoning:
+      question: "<what was decided>"
+      selected: "<chosen approach>"
+      confidence: <0.0-1.0>
+
+result_summary: "<1-2 sentence summary>"
+```
+
+## Node type mapping
+
+| Agent Action | OSOP Node Type | Subtype |
+|---|---|---|
+| Read/explore files | `mcp` | `tool` |
+| Edit/write files | `mcp` | `tool` |
+| Run shell commands | `cli` | `script` |
+| Run tests | `cicd` | `test` |
+| Git operations | `git` | `commit` / `branch` / `pr` |
+| Analyze/reason about code | `agent` | `llm` |
+| Search codebase | `mcp` | `tool` |
+| Ask user a question | `human` | `input` |
+| User reviews/approves | `human` | `review` |
+| API calls | `api` | `rest` |
+
+## Where to save
+
+Save to `sessions/` in the project root:
+- `sessions/YYYY-MM-DD-<short-desc>.osop`
+- `sessions/YYYY-MM-DD-<short-desc>.osoplog.yaml`
+
+## When to generate
+
+- After completing multi-step tasks (3+ distinct steps)
+- After debugging sessions
+- After feature implementations
+- After refactoring work
+- When the user asks "what did you do?"

--- a/rules/osop-session-logging-cursorrules-prompt-file/.cursorrules
+++ b/rules/osop-session-logging-cursorrules-prompt-file/.cursorrules
@@ -16,7 +16,7 @@ id: "session-<short-description>"
 name: "<What you did>"
 description: "<1-2 sentence summary>"
 version: "1.0.0"
-tags: [windsurf, <relevant-tags>]
+tags: [cursor, <relevant-tags>]
 
 nodes:
   - id: "<step-id>"
@@ -52,7 +52,7 @@ ended_at: "<ISO timestamp>"
 duration_ms: <total ms>
 
 runtime:
-  agent: "windsurf"
+  agent: "cursor"
   model: "<model>"
 
 node_records:


### PR DESCRIPTION
## Summary

- Adds a cursor rule for **OSOP session logging** — records AI coding sessions as structured `.osop` + `.osoplog.yaml` workflow files
- OSOP (Open Standard for Orchestration Protocol) is a universal workflow protocol that works across all AI coding tools, not just Cursor
- The rule instructs Cursor to automatically generate session logs after multi-step tasks (debugging, feature implementation, refactoring)

## What's included

- `rules/osop-session-logging-cursorrules-prompt-file/.cursorrules` — the cursor rule file
- README entry under **Utilities**

## Links

- View session logs interactively: https://osop-editor.vercel.app
- Agent rules repo: https://github.com/Archie0125/osop-agent-rules
- OSOP spec: https://github.com/Archie0125/osop-spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added OSOP Session Logging guidelines for recording multi-step AI coding sessions.
  * Instructs generating structured OSOP-format workflow definitions and execution records (YAML) capturing session metadata, node graphs, per-step outputs, tooling, timing, and results.
  * Specifies naming/location conventions for saved session artifacts.
  * Logged sessions can be opened and inspected at osop-editor.vercel.app
  * Applicable to complex tasks, debugging, refactoring, and post-work summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->