### PR TITLE
Add LynxPrompt to Directories section

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 - [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
+- [LynxPrompt](https://lynxprompt.com) - Open-source platform for managing AI coding rules (AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md) with web marketplace, CLI, VS Code extension, and self-hosting support.
 
 ## How to Use
 


### PR DESCRIPTION
Adding LynxPrompt to the Directories section — it's a platform I built for browsing, sharing, and pulling AI coding rules (.cursorrules, AGENTS.md, CLAUDE.md, copilot-instructions.md, etc.).

You can use it from the web at lynxprompt.com, via CLI (`npx lynxprompt`), or through the VS Code extension. It's open source (GPL-3.0) and self-hostable with Docker/Helm.

Repo: https://github.com/GeiserX/LynxPrompt