### PR TITLE
Add framecraft demo video generation cursor rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [Code Guidelines](./rules/code-guidelines-cursorrules-prompt-file/.cursorrules) - Cursor rules for code development with guidelines integration.
 - [Code Style Consistency](./rules/code-style-consistency-cursorrules-prompt-file/.cursorrules) - Cursor rules for code development with style consistency integration.
 - [DragonRuby Best Practices](./rules/dragonruby-best-practices-cursorrules-prompt-file/.cursorrules) - Cursor rules for DragonRuby development with best practices integration.
+- [Framecraft (Demo Video Generation)](./rules/framecraft-demo-video-cursorrules-prompt-file/.cursorrules) - Cursor rules for creating polished demo videos from prompts using framecraft with Playwright, ffmpeg, and edge-tts.
 - [Graphical Apps Development](./rules/graphical-apps-development-cursorrules-prompt-file/.cursorrules) - Cursor rules for graphical apps development with integration.
 - [Meta-Prompt](./rules/meta-prompt-cursorrules-prompt-file/.cursorrules) - Cursor rules for meta-prompt development with integration.
 - [Next.js (Type LLM)](./rules/next-type-llm/.cursorrules) - Cursor rules for Next.js development with Type LLM integration.

--- a/rules/framecraft-demo-video-cursorrules-prompt-file/.cursorrules
+++ b/rules/framecraft-demo-video-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,49 @@
+You are an expert at creating polished demo videos using framecraft.
+
+## framecraft Demo Video Generation
+
+When the user asks you to create a demo video, product walkthrough, or marketing clip:
+
+1. **Story Structure**: Plan a clear narrative arc — hook, context, feature showcase, and call-to-action.
+2. **Scene Design**: Break the video into scenes. Each scene has:
+   - An HTML template (rendered via Playwright)
+   - Narration text (synthesized via edge-tts)
+   - Duration and transition settings
+3. **Visual Hierarchy**: Use large headlines, consistent branding, and smooth transitions. Avoid clutter.
+4. **Narration**: Write concise, natural narration. Match pacing to visuals. Use pauses for emphasis.
+5. **Pipeline**: Use framecraft's CLI or MCP server to render scenes, stitch with ffmpeg, and validate output.
+
+### Key Commands
+
+```bash
+# Initialize a new demo project
+uv run python framecraft.py init my-demo
+
+# Render all scenes
+uv run python framecraft.py render scenes.json --auto-duration
+
+# Render a single scene for preview
+uv run python framecraft.py render scenes.json --scene 2
+
+# Validate the final video
+uv run python framecraft.py validate output.mp4
+
+# Export with optimized settings
+uv run python framecraft.py export output.mp4
+```
+
+### Best Practices
+
+- Keep scenes under 10 seconds each for pacing
+- Use 1920x1080 resolution for professional output
+- Include a title card and closing card
+- Test narration timing before final render
+- Use the `--auto-duration` flag to match scene length to narration
+
+### Tech Stack
+
+- Python 3.11+, Playwright (chromium), ffmpeg, edge-tts
+- HTML/CSS templates for scene rendering
+- JSON configuration for scene definitions
+
+Repository: https://github.com/vaddisrinivas/framecraft


### PR DESCRIPTION
## Summary

- Adds `.cursorrules` for [framecraft](https://github.com/vaddisrinivas/framecraft) — an open-source (MIT) tool that generates polished demo videos from prompts using Playwright, ffmpeg, and edge-tts
- Rules cover story structure, scene design, narration, and the CLI pipeline
- Entry added alphabetically in the **Other** section

## Details

framecraft is an LLM skill and plugin for demo video creation. It teaches AI assistants how to plan story arcs, design HTML scenes, write narration, and orchestrate the render pipeline. Works with Cursor via `.cursorrules` to guide AI-assisted video production workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions and best practices for generating polished demo videos using Framecraft, including narrative planning, scene composition, visual hierarchy guidelines, and rendering pipeline details.
  * New configuration file with command examples and workflow guidance now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->