### PR TITLE
Add code-tour AI walkthrough generation cursor rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Documentation
 
+- [Code Tour (AI Walkthrough Generator)](./rules/code-tour-ai-walkthrough-cursorrules-prompt-file/.cursorrules) - Cursor rules for generating CodeTour .tour files — persona-targeted, step-by-step codebase walkthroughs linked to real files and line numbers.
 - [Gherkin Style Testing](./rules/gherkin-style-testing-cursorrules-prompt-file/.cursorrules) - Cursor rules for Gherkin style testing development with integration.
 - [How-To Documentation](./rules/how-to-documentation-cursorrules-prompt-file/.cursorrules) - Cursor rules for how-to documentation development with integration.
 

--- a/rules/code-tour-ai-walkthrough-cursorrules-prompt-file/.cursorrules
+++ b/rules/code-tour-ai-walkthrough-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,52 @@
+You are an expert at creating CodeTour walkthrough files using the code-tour AI generator.
+
+## Code Tour Generation
+
+When the user asks you to create a code tour, onboarding guide, or codebase walkthrough:
+
+1. **Identify the Audience**: Determine the persona — new hire, reviewer, architect, or contributor.
+2. **Plan the Route**: Select key files and functions that tell the story of the codebase or feature.
+3. **Write Step Annotations**: Each step links to a specific file and line number with a clear, concise explanation.
+4. **Narrative Flow**: Steps should follow a logical reading order — entry point to internals, or feature flow from UI to backend.
+5. **Generate .tour Files**: Output valid CodeTour JSON that works with the VS Code CodeTour extension.
+
+### Key Commands
+
+```bash
+# Generate a tour for the current project
+claude -p "create a code tour for this repo"
+
+# Generate a tour for a specific feature or PR
+claude -p "create a code tour for the authentication flow"
+
+# Generate an onboarding tour for new developers
+claude -p "create an onboarding tour targeting new hires"
+```
+
+### Tour File Format
+
+Tours are saved as `.tours/*.tour` JSON files compatible with the VS Code CodeTour extension:
+
+```json
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "Tour Title",
+  "steps": [
+    {
+      "file": "src/main.py",
+      "line": 42,
+      "description": "Step explanation here"
+    }
+  ]
+}
+```
+
+### Best Practices
+
+- Keep tours between 5-15 steps for readability
+- Start from the entry point or most important file
+- Use clear, jargon-free language appropriate for the target audience
+- Reference actual line numbers that exist in the current codebase
+- Group related concepts into separate tours rather than one mega-tour
+
+Repository: https://github.com/vaddisrinivas/code-tour


### PR DESCRIPTION
## Summary

- Adds `.cursorrules` for [code-tour](https://github.com/vaddisrinivas/code-tour) — an open-source (MIT) AI-powered CodeTour walkthrough generator
- Rules cover audience targeting, step planning, narrative flow, and .tour file generation
- Entry added alphabetically in the **Documentation** section

## Details

code-tour generates CodeTour `.tour` files — persona-targeted, step-by-step codebase walkthroughs that link to real files and line numbers. Compatible with the VS Code CodeTour extension. The cursor rules guide AI assistants through planning and generating effective code tours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with reference to new Cursor rules for CodeTour generation

* **Chores**
  * Added configuration file enabling generation of step-by-step code walkthroughs with file references and line-number annotations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->