### PR TITLE
Add ctxlint — linter for .cursorrules files

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Utilities
 
+- [ctxlint](https://github.com/YawLabs/ctxlint) - Lints .cursorrules and other AI context files against your codebase. Catches broken paths, wrong commands, and stale context.
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
 
 ## Directories


### PR DESCRIPTION
## Summary

[ctxlint](https://github.com/YawLabs/ctxlint) is an open-source linter for AI context files including `.cursorrules`, `CLAUDE.md`, and `copilot-instructions.md`. It validates file paths, shell commands, and references against your actual codebase to catch broken paths, wrong commands, and stale context.

- **GitHub**: https://github.com/YawLabs/ctxlint
- **npm**: [@yawlabs/ctxlint](https://www.npmjs.com/package/@yawlabs/ctxlint)
- **License**: MIT

Added to the **Utilities** section in alphabetical order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ctxlint utility reference to the README, a linter for `.cursorrules` and AI context files that detects broken paths, incorrect commands, and stale context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->