### PR TITLE
Add Alpha Skills — quantitative factor research skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Other
 
+- [Alpha Skills](https://github.com/VernonOY/alpha-skills) - Quantitative factor research skills for Cursor. Evaluate factors, run backtests, mine new alpha — all through natural language.
 - [ASCII Simulation Game](./rules/ascii-simulation-game-cursorrules-prompt-file/.cursorrules) - Cursor rules for ASCII simulation game development.
 - [Code Guidelines](./rules/code-guidelines-cursorrules-prompt-file/.cursorrules) - Cursor rules for code development with guidelines integration.
 - [Code Style Consistency](./rules/code-style-consistency-cursorrules-prompt-file/.cursorrules) - Cursor rules for code development with style consistency integration.

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Other
 
-- [Alpha Skills](https://github.com/VernonOY/alpha-skills) - Quantitative factor research skills for Cursor. Evaluate factors, run backtests, mine new alpha — all through natural language.
+- [Alpha Skills](./rules/alpha-skills-quant-factor-research/.cursorrules) - Quantitative factor research skills for Cursor. Evaluate factors, run backtests, mine new alpha — all through natural language.
 - [ASCII Simulation Game](./rules/ascii-simulation-game-cursorrules-prompt-file/.cursorrules) - Cursor rules for ASCII simulation game development.
 - [Code Guidelines](./rules/code-guidelines-cursorrules-prompt-file/.cursorrules) - Cursor rules for code development with guidelines integration.
 - [Code Style Consistency](./rules/code-style-consistency-cursorrules-prompt-file/.cursorrules) - Cursor rules for code development with style consistency integration.

--- a/rules/alpha-skills-quant-factor-research/.cursorrules
+++ b/rules/alpha-skills-quant-factor-research/.cursorrules
@@ -1,0 +1,21 @@
+# Alpha Skills — Quantitative Factor Research
+
+You are a senior quantitative researcher. Use these skills for factor research:
+
+## Skills
+
+- **alpha-discover**: Design factors from natural language. Say "find me a low-volatility factor".
+- **alpha-evaluate**: Multi-level evaluation (IC/ICIR/quintile/robustness). Say "evaluate reversal_5".
+- **alpha-mine**: Automated factor mining with IC screening. Say "mine 50 factors".
+- **alpha-library**: Factor registry with lifecycle management. Say "show my factor library".
+- **alpha-backtest**: Single/multi-factor portfolio backtesting. Say "backtest with pv_diverge + turnover".
+- **alpha-monitor**: Detect IC decay and health issues. Say "check factor health".
+- **alpha-report**: Generate comprehensive analysis reports. Say "generate factor report".
+
+## Full skill definitions
+
+For complete skill implementations, see: https://github.com/VernonOY/alpha-skills/tree/main/skills
+
+## Markets Supported
+
+A-share (China), Hong Kong, US equities. Auto-adapts trading rules per market.


### PR DESCRIPTION
Adding [Alpha Skills](https://github.com/VernonOY/alpha-skills) — a set of 7 AI skills for quantitative factor research.

Works as Cursor rules files. Skills include factor discovery, evaluation (IC/ICIR/quintile), automated mining, backtesting, monitoring, and reporting. Supports A-share, HK, and US markets. All self-contained, no external dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Alpha Skills" entry describing quantitative factor research capabilities in the README.
  * Documented a new set of Alpha Skills for quantitative factor research (discovery, evaluation, mining, library, backtesting, monitoring, reporting) and noted supported market coverage and adaptation for different markets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->