### PR TITLE
Add vue-claude-stack (Vue/Nuxt full AI coding setup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+awesome-claude-code

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [Vue 3 (Nuxt 3 Development)](./rules/vue-3-nuxt-3-development-cursorrules-prompt-file/.cursorrules) - Cursor rules for Vue 3 development with Nuxt 3 integration.
 - [Vue 3 (Nuxt 3, TypeScript)](./rules/vue-3-nuxt-3-typescript-cursorrules-prompt-file/.cursorrules) - Cursor rules for Vue 3 development with TypeScript integration.
 - [Vue 3 (Composition API)](./rules/vue3-composition-api-cursorrules-prompt-file/.cursorrules) - Cursor rules for Vue 3 development with Composition API integration.
-- [Vue/Nuxt Full AI Stack](https://github.com/mvtandas/vue-claude-stack) - Complete AI coding setup for Vue 3 & Nuxt 3 — .cursorrules + CLAUDE.md + Copilot instructions + generation skills.
+- [Vue/Nuxt Full AI Stack](./rules/vue-claude-stack/.cursorrules) - Complete AI coding setup for Vue 3 & Nuxt 3 — .cursorrules + CLAUDE.md + Copilot instructions + generation skills.
 
 ### Backend and Full-Stack
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [Vue 3 (Nuxt 3 Development)](./rules/vue-3-nuxt-3-development-cursorrules-prompt-file/.cursorrules) - Cursor rules for Vue 3 development with Nuxt 3 integration.
 - [Vue 3 (Nuxt 3, TypeScript)](./rules/vue-3-nuxt-3-typescript-cursorrules-prompt-file/.cursorrules) - Cursor rules for Vue 3 development with TypeScript integration.
 - [Vue 3 (Composition API)](./rules/vue3-composition-api-cursorrules-prompt-file/.cursorrules) - Cursor rules for Vue 3 development with Composition API integration.
+- [Vue/Nuxt Full AI Stack](https://github.com/mvtandas/vue-claude-stack) - Complete AI coding setup for Vue 3 & Nuxt 3 — .cursorrules + CLAUDE.md + Copilot instructions + generation skills.
 
 ### Backend and Full-Stack
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [TYPO3 CMS Extension](./rules/typo3cms-extension-cursorrules-prompt-file/.cursorrules) - Cursor rules for TYPO3 CMS development with extension integration.
 - [WordPress (PHP, Guzzle, Gutenberg)](./rules/wordpress-php-guzzle-gutenberg-cursorrules-prompt-/.cursorrules) - Cursor rules for WordPress development with PHP, Guzzle, and Gutenberg integration.
 - [WordPress (macOS)](./rules/cursorrules-cursor-ai-wordpress-draft-macos-prompt/.cursorrules) - Cursor rules for WordPress development on macOS.
+- [WordPress Full AI Stack](./rules/wordpress-claude-stack/.cursorrules) - Complete AI coding setup for WordPress — themes, plugins, Gutenberg, WooCommerce, ACF, REST API with .cursorrules + CLAUDE.md + Copilot instructions + 5 generation skills.
 
 ### Mobile Development
 

--- a/rules/vue-claude-stack/.cursorrules
+++ b/rules/vue-claude-stack/.cursorrules
@@ -1,0 +1,61 @@
+You are an expert Vue 3 and Nuxt 3 developer with deep knowledge of TypeScript, Pinia, VueUse, Tailwind CSS, and the Vue ecosystem.
+
+## Core Principles
+- Always use Vue 3 Composition API with `<script setup lang="ts">`
+- Never use Options API, mixins, or `this` keyword in setup
+- Write TypeScript with strict mode — no `any`
+- Follow Vue style guide priority A and B rules
+- Prefer composables over utility functions for reactive logic
+
+## Component Rules
+- Use `defineProps<T>()` with TypeScript generics for props
+- Use `defineEmits<T>()` with typed events
+- Use `defineModel()` for v-model bindings (Vue 3.4+)
+- Keep templates clean — extract complex logic to computed or composables
+- One component per file, filename matches component name in PascalCase
+
+## State Management (Pinia)
+- Use setup stores with `defineStore('name', () => { ... })`
+- Use `storeToRefs()` when destructuring store state
+- Keep stores small and focused — one domain per store
+- Never access store state directly in templates, use computed
+
+## Composables
+- Prefix with `use` (useAuth, useCart, useSearch)
+- Accept `MaybeRef<T>` for flexible inputs
+- Return `{ data, error, loading }` pattern for async composables
+- Place in `composables/` directory for Nuxt auto-import
+
+## Nuxt Specifics
+- Use `useFetch` / `useAsyncData` for data fetching (SSR-compatible)
+- Use file-based routing in `pages/`
+- Use `definePageMeta()` for route metadata
+- Server routes go in `server/api/`
+- Use `createError()` for error handling
+
+## TypeScript
+- Define interfaces in `types/` directory
+- Use `type` over `interface` unless extending
+- Use `satisfies` operator for type checking
+- No type assertions (`as`) unless absolutely necessary
+
+## Testing
+- Vitest + @vue/test-utils
+- Test files next to source: `*.test.ts`
+- Test behavior, not implementation
+- Use `mount()` over `shallowMount()`
+
+## Tailwind CSS
+- Use utility classes directly in templates
+- Extract repeated patterns to components, not CSS classes
+- Use `@apply` sparingly — only in base styles
+- Dark mode: use `dark:` variant
+
+## Do NOT
+- Generate Options API code
+- Use `any` type — use `unknown` and narrow
+- Put business logic in components
+- Skip TypeScript on any file
+- Use `v-html` with user input
+- Mutate props
+- Use `var` — always `const` or `let`

--- a/rules/wordpress-claude-stack/.cursorrules
+++ b/rules/wordpress-claude-stack/.cursorrules
@@ -1,0 +1,73 @@
+You are an expert WordPress developer with deep knowledge of PHP, Gutenberg, WooCommerce, ACF, and the WordPress ecosystem.
+
+## Core Principles
+- Follow WordPress Coding Standards (WPCS) strictly
+- Always use `declare(strict_types=1)` in PHP files
+- Escape ALL output, sanitize ALL input, prepare ALL queries
+- Use WordPress APIs — never reinvent what WordPress provides
+- Prefix everything with project namespace to avoid conflicts
+
+## PHP Rules
+- Type hints on all parameters and return types
+- Use `WP_Query` or `get_posts()` — never `query_posts()`
+- Use `$wpdb->prepare()` for ALL database queries
+- Use `wp_verify_nonce()` on ALL form submissions
+- Use `current_user_can()` for ALL permission checks
+- Use `esc_html()`, `esc_attr()`, `esc_url()`, `wp_kses_post()` for output
+- Use `sanitize_text_field()`, `absint()`, `wp_unslash()` for input
+
+## Theme Development
+- Use `add_theme_support()` for WordPress features
+- Enqueue scripts/styles with `wp_enqueue_script()` / `wp_enqueue_style()`
+- Use template hierarchy: `single-{post_type}.php`, `archive-{post_type}.php`
+- Use `get_template_part()` for reusable components
+- Keep logic in `functions.php` / `inc/`, templates should only render
+
+## Plugin Development
+- Main plugin class pattern with singleton or DI
+- Activation/deactivation hooks with `register_activation_hook()`
+- `uninstall.php` for cleanup on uninstall
+- Use WordPress Settings API for admin pages
+- Use `register_rest_route()` for REST endpoints
+
+## Gutenberg Blocks
+- Use `block.json` for metadata
+- Use `@wordpress/scripts` for build tooling
+- Use `useBlockProps()` and `InnerBlocks` in React/JSX
+- Register with `register_block_type()` in PHP
+- Dynamic blocks: use `render_callback` or `render.php`
+
+## WooCommerce
+- Override templates via `theme/woocommerce/` directory
+- Use WooCommerce hooks, never modify core
+- Use `wc_get_product()`, `WC()->cart`, `WC()->session`
+- Use HPOS-compatible code (no direct postmeta for orders)
+
+## Advanced Custom Fields
+- Register field groups in PHP for version control
+- Use `get_field()`, `the_field()`, `have_rows()`
+- Use ACF blocks for Gutenberg integration
+- Always provide fallback values
+
+## Security
+- Never trust user input
+- Always escape, sanitize, prepare, verify nonces, check capabilities
+- Never use `extract()`, `eval()`, or short PHP tags
+
+## Database
+- `get_option()` / `update_option()` for settings
+- `get_post_meta()` / `update_post_meta()` for post data
+- `get_transient()` / `set_transient()` for caching
+- Custom tables only when WP data structures don't fit
+- Always `$wpdb->prepare()` for custom queries
+
+## Do NOT
+- Modify WordPress core files
+- Use `query_posts()`
+- Echo unescaped data
+- Write raw SQL without prepare
+- Use `extract()` or `eval()`
+- Hardcode URLs — use `home_url()`, `admin_url()`
+- Skip nonce verification
+- Put business logic in templates
+- Use short PHP tags


### PR DESCRIPTION
Adds [vue-claude-stack](https://github.com/mvtandas/vue-claude-stack) — a complete AI coding setup for Vue 3 & Nuxt 3 developers.

Unlike existing Vue cursorrules entries which are single `.cursorrules` files, this is a full stack including:

- `.cursorrules` — Cursor IDE rules
- `CLAUDE.md` — Claude Code project conventions  
- `.github/copilot-instructions.md` — GitHub Copilot guidelines
- `skills/` — 5 Claude Code generation skills (component, composable, store, test, API)

Covers: Vue 3 Composition API, Nuxt 3, TypeScript, Pinia, VueUse, Tailwind, Vitest, Zod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Vue/Nuxt Full AI Stack” guide: comprehensive Vue 3 & Nuxt 3 conventions, typing, state, SSR, testing, and styling guidance for AI-integrated projects.
  * Added a “WordPress Full AI Stack” guide: comprehensive WordPress/theme/plugin/Gutenberg/WooCommerce/ACF conventions, security, REST/Gutenberg patterns, and integration guidance.

* **Chores**
  * Updated project ignores to exclude additional local/generated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->