### PR TITLE
Add contextarch CLI to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Utilities
 
-- [contextarch](https://github.com/ksoventures/contextarch-cli) - CLI (`npx contextarch init`) that detects your project stack and generates `.cursorrules`, `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` from a single interactive wizard. Reads `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, and more to pick opinionated rules tuned to your stack. Supports 30+ stacks including React, Next.js, Vue, SvelteKit, FastAPI, Django, Go, Rust, Electron. MIT licensed.
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
+- [contextarch](https://github.com/ksoventures/contextarch-cli) - CLI (`npx contextarch init`) that auto-detects your project stack from manifests (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, etc.) and generates `.cursorrules`, `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` from a single wizard. Supports 30+ stacks; MIT licensed.
 
 ## Directories
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Utilities
 
+- [contextarch](https://github.com/ksoventures/contextarch-cli) - CLI (`npx contextarch init`) that detects your project stack and generates `.cursorrules`, `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` from a single interactive wizard. Reads `package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, and more to pick opinionated rules tuned to your stack. Supports 30+ stacks including React, Next.js, Vue, SvelteKit, FastAPI, Django, Go, Rust, Electron. MIT licensed.
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
 
 ## Directories


### PR DESCRIPTION
Hi! Adding contextarch to the Utilities section, alongside the
  existing Cursor Watchful Headers entry.

  contextarch (`npx contextarch init`) is an open-source CLI that detects
  a project's stack and generates four AI context files — .cursorrules,
  AGENTS.md, CLAUDE.md, and .github/copilot-instructions.md — from one
  interactive wizard. It fills a small gap: instead of copy-pasting
  .cursorrules from a blog post and separately maintaining the other
  three, contextarch generates all four from one source, with stack-specific
  rules for 30+ stacks (React, Next.js, Vue, SvelteKit, FastAPI, Django,
  Go, Rust, Electron, etc).

  - Source: https://github.com/ksoventures/contextarch-cli
  - npm: https://www.npmjs.com/package/contextarch
  - MIT licensed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a reference to the contextarch utility in the README, including its GitHub link and CLI usage, describing how it can auto-detect project stacks from common manifest files (Node/Python/Go/Rust) and generate recommended project configuration and guidance files to help initialize project structure and related documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->