### PR TITLE
Add cursor-product-kit link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 - [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
+- [cursor-product-kit](https://github.com/Natalee21/cursor-product-kit) - Rules, skills and global context for product managers, marketers and vibe-coders. Includes 8 rules, 12 skills and ready mcp.json.
 
 ## How to Use
 

--- a/README.md
+++ b/README.md
@@ -288,10 +288,9 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
 
 ## Directories
-
-- [CursorList](https://cursorlist.com)
-- [CursorDirectory](https://cursor.directory/)
 - [cursor-product-kit](https://github.com/Natalee21/cursor-product-kit) - Rules, skills and global context for product managers, marketers and vibe-coders. Includes 8 rules, 12 skills and ready mcp.json.
+- [CursorDirectory](https://cursor.directory/)
+- [CursorList](https://cursorlist.com)
 
 ## How to Use
 


### PR DESCRIPTION
Added cursor-product-kit to the Directories section — a collection of Cursor rules, skills and global context for product managers, marketers and vibe-coders.

Includes:
- 8 rules (global context, frontend/backend architecture, safe editing, debugging, TypeScript, UX thinking, deploy safety)
- 12 skills (product analyst, SMM analyst, copywriter, AI bot builder, n8n automation, landing page builder, marketer, SaaS architect and more)
- Ready mcp.json with context7, Figma, Playwright and Miro

GitHub: https://github.com/Natalee21/cursor-product-kit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an entry for the cursor-product-kit, noting available rules, skills, and configuration resources.
  * Cleaned up formatting in the directory listing and reordered entries so CursorList now follows CursorDirectory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->