### PR TITLE
Add Emdash Skills to Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,9 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ## Directories
 
-- [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
+- [CursorList](https://cursorlist.com)
+- [Emdash Skills](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS for 30+ AI coding tools. 94 reference docs, 18 agents, 30 platform variants.
 
 ## How to Use
 


### PR DESCRIPTION
Adds [Emdash Skills](https://github.com/megabytespace/claude-skills) to the Directories section.

**What it is:** A 14-category autonomous product-building OS for 30+ AI coding tools. 94 reference docs, 18 agents, 30 platform variants. One-line prompts to deployed products on Cloudflare Workers.

Placed in the Directories section since it's a comprehensive external resource collection rather than a single `.cursorrules` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the Directories section in README for improved navigation
  * Added new Emdash Skills link reference to the Directories section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->