### PR TITLE
Add EnigmAgent MCP — Local Secrets Vault cursor rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,13 +271,13 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [Code Guidelines](./rules/code-guidelines-cursorrules-prompt-file/.cursorrules) - Cursor rules for code development with guidelines integration.
 - [Code Style Consistency](./rules/code-style-consistency-cursorrules-prompt-file/.cursorrules) - Cursor rules for code development with style consistency integration.
 - [DragonRuby Best Practices](./rules/dragonruby-best-practices-cursorrules-prompt-file/.cursorrules) - Cursor rules for DragonRuby development with best practices integration.
+- [EnigmAgent MCP — Local Secrets Vault](./rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules) - Cursor rules that teach the agent to route every credential through a local AES-256-GCM encrypted vault (enigmagent-mcp) instead of pasting secrets into chat or source files.
 - [Graphical Apps Development](./rules/graphical-apps-development-cursorrules-prompt-file/.cursorrules) - Cursor rules for graphical apps development with integration.
 - [Meta-Prompt](./rules/meta-prompt-cursorrules-prompt-file/.cursorrules) - Cursor rules for meta-prompt development with integration.
 - [Next.js (Type LLM)](./rules/next-type-llm/.cursorrules) - Cursor rules for Next.js development with Type LLM integration.
 - [Unity (C#)](./rules/unity-cursor-ai-c-cursorrules-prompt-file/.cursorrules) - Cursor rules for Unity development with C# integration.
 - [Web App Optimization](./rules/web-app-optimization-cursorrules-prompt-file/.cursorrules) - Cursor rules for web app development with optimization integration.
 - [Code Pair Interviews](./rules/code-pair-interviews/.cursorrules) - Cursor rules for code pair interviews development with integration.
-- [EnigmAgent MCP — Local Secrets Vault](./rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules) - Cursor rules that teach the agent to route every credential through a local AES-256-GCM encrypted vault (enigmagent-mcp) instead of pasting secrets into chat or source files.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [Unity (C#)](./rules/unity-cursor-ai-c-cursorrules-prompt-file/.cursorrules) - Cursor rules for Unity development with C# integration.
 - [Web App Optimization](./rules/web-app-optimization-cursorrules-prompt-file/.cursorrules) - Cursor rules for web app development with optimization integration.
 - [Code Pair Interviews](./rules/code-pair-interviews/.cursorrules) - Cursor rules for code pair interviews development with integration.
+- [EnigmAgent MCP — Local Secrets Vault](./rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules) - Cursor rules that teach the agent to route every credential through a local AES-256-GCM encrypted vault (enigmagent-mcp) instead of pasting secrets into chat or source files.
 
 ### Documentation
 

--- a/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules
+++ b/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules
@@ -78,15 +78,17 @@ To use it as an MCP server in Claude Code or Cursor, add the following to `~/.cu
 }
 ```
 
-A concrete cross-platform example using the default vault location:
+**Important:** `~` and `%USERPROFILE%` are **not** expanded when the MCP host spawns the process — the string is passed verbatim as `argv` and Node.js `fs` does not perform tilde or environment-variable expansion. Always supply a real absolute path. Cross-platform examples:
 
 ```jsonc
-// macOS / Linux
-{ "mcpServers": { "enigmagent": { "command": "npx", "args": ["-y", "enigmagent-mcp", "--vault", "~/.enigmagent/vault.json"] } } }
+// macOS / Linux — replace /Users/<you> with your actual home directory
+{ "mcpServers": { "enigmagent": { "command": "npx", "args": ["-y", "enigmagent-mcp", "--vault", "/Users/<you>/.enigmagent/vault.json"] } } }
 
-// Windows
-{ "mcpServers": { "enigmagent": { "command": "npx", "args": ["-y", "enigmagent-mcp", "--vault", "%USERPROFILE%\.enigmagent\vault.json"] } } }
+// Windows — double backslashes required for valid JSON
+{ "mcpServers": { "enigmagent": { "command": "npx", "args": ["-y", "enigmagent-mcp", "--vault", "C:\\Users\\<you>\\.enigmagent\\vault.json"] } } }
 ```
+
+Alternatively, set the **`ENIGMAGENT_VAULT`** environment variable in the MCP host's env block to avoid hard-coding the path in the config file.
 
 Repository: https://github.com/Agnuxo1/enigmagent-mcp
 npm: https://www.npmjs.com/package/enigmagent-mcp

--- a/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules
+++ b/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules
@@ -13,7 +13,9 @@ You have access to the **enigmagent-mcp** Model Context Protocol server, which p
 
 4. **No environment-variable substitution from chat.** Never write `process.env.X = "<actual-value>"` or shell-export a literal secret. Always reference it indirectly: read from the vault at runtime, or load through `dotenv` from a gitignored `.env`.
 
-5. **`.gitignore` discipline.** Before any commit, verify `.env`, `.env.local`, `*.pem`, `*.key`, `id_rsa`, and `~/.enigmagent/` are gitignored. Add them if missing.
+5. **`.gitignore` discipline.** Before any commit, apply two layers of protection:
+   - **Repository `.gitignore`** — verify that `.env`, `.env.local`, `*.pem`, `*.key`, and `id_rsa` are listed. Add them if missing. These patterns match repository-relative paths and are tracked with the project.
+   - **System-level protection for `~/.enigmagent/`** — the vault directory lives outside the repository and cannot be covered by `.gitignore` (Git does not support tilde expansion or absolute paths in `.gitignore`). Protect it by adding `.enigmagent/` to the user's global gitignore (`~/.gitignore_global`, configured with `git config --global core.excludesfile`) or to `$GIT_DIR/info/exclude` for individual repositories.
 
 ## Workflow Patterns
 

--- a/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules
+++ b/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules
@@ -13,9 +13,9 @@ You have access to the **enigmagent-mcp** Model Context Protocol server, which p
 
 4. **No environment-variable substitution from chat.** Never write `process.env.X = "<actual-value>"` or shell-export a literal secret. Always reference it indirectly: read from the vault at runtime, or load through `dotenv` from a gitignored `.env`.
 
-5. **`.gitignore` discipline.** Before any commit, apply two layers of protection:
-   - **Repository `.gitignore`** — verify that `.env`, `.env.local`, `*.pem`, `*.key`, and `id_rsa` are listed. Add them if missing. These patterns match repository-relative paths and are tracked with the project.
-   - **System-level protection for `~/.enigmagent/`** — the vault directory lives outside the repository and cannot be covered by `.gitignore` (Git does not support tilde expansion or absolute paths in `.gitignore`). Protect it by adding `.enigmagent/` to the user's global gitignore (`~/.gitignore_global`, configured with `git config --global core.excludesfile`) or to `$GIT_DIR/info/exclude` for individual repositories.
+5. **`.gitignore` discipline — repository level.** Before any commit, verify the project's `.gitignore` lists at minimum: `.env`, `.env.local`, `*.pem`, `*.key`, `id_rsa`. Add them if missing.
+
+6. **System-level secrets directory — separate concern.** The vault file itself (default `~/.enigmagent/`) lives outside the repository. It is **not** a candidate for the project `.gitignore` because the directory is never inside the repo to begin with. Protect it via the user's global gitignore (`git config --global core.excludesfile`) or by simply keeping the path outside any tracked working tree. If you ever see `~/.enigmagent/` proposed as an entry in a project `.gitignore`, that's a hint the user has misplaced their vault — flag it.
 
 ## Workflow Patterns
 

--- a/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules
+++ b/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,72 @@
+# EnigmAgent — Local Encrypted Secrets Vault Rules
+
+You have access to the **enigmagent-mcp** Model Context Protocol server, which provides a local encrypted vault on the user's machine. Vault data is encrypted with AES-256-GCM using an Argon2id-derived key, and never leaves the local filesystem.
+
+## Hard Rules
+
+1. **Never paste secrets into chat or files.** API keys, access tokens, recovery phrases, passwords, private keys, signing keys, JWTs, OAuth refresh tokens, database connection strings with credentials, and any value the user labels "secret", "private", or "sensitive" must go through the vault — never inlined, never echoed back, never written into source files.
+
+2. **Never log, print, or summarize a vault value back to the user.** When you retrieve a secret, use it for the immediate operation only. If you need to confirm the operation succeeded, say "retrieved" — do not display the value.
+
+3. **Detect-and-redirect.** If the user pastes a credential into the conversation, refuse to commit it. Suggest moving it into the vault first:
+   > "I noticed an API key in your message. Let's store it in EnigmAgent instead — that way it stays encrypted on your machine and out of chat history. Should I save it as `<key-name>`?"
+
+4. **No environment-variable substitution from chat.** Never write `process.env.X = "<actual-value>"` or shell-export a literal secret. Always reference it indirectly: read from the vault at runtime, or load through `dotenv` from a gitignored `.env`.
+
+5. **`.gitignore` discipline.** Before any commit, verify `.env`, `.env.local`, `*.pem`, `*.key`, `id_rsa`, and `~/.enigmagent/` are gitignored. Add them if missing.
+
+## Workflow Patterns
+
+### Storing a new secret
+When the user says "save this key" / "remember this credential" / "store this token":
+1. Ask for a stable name (kebab-case): `openai-prod-key`, `stripe-test-secret`, etc.
+2. Call the EnigmAgent MCP `set` tool with `{ name, value }`.
+3. Confirm with name only: "Saved as `openai-prod-key`."
+
+### Reading a secret in code
+When generating code that needs a credential:
+- Prefer reading from `process.env` / `os.environ` populated via dotenv at startup.
+- For agent workflows, call the EnigmAgent `get` tool inline rather than embedding the value.
+- Never cache the retrieved value in a file the user has not explicitly asked you to write.
+
+### Listing or rotating
+- The `list` tool returns names only — safe to display.
+- For rotation, call `set` with the same name and the new value. Suggest deleting the old credential at the source provider.
+
+## Detection Heuristics
+
+Treat any of the following as a "this should be in the vault" trigger:
+
+- Strings matching `sk-[A-Za-z0-9]{20,}`, `ghp_[A-Za-z0-9]{36,}`, `xox[bp]-[A-Za-z0-9-]+`, `AIza[0-9A-Za-z_-]{35}`, `AKIA[0-9A-Z]{16}`
+- 12 or 24 word phrases that look like BIP-39 mnemonics
+- PEM blocks (`-----BEGIN ... PRIVATE KEY-----`)
+- Connection strings with `:password@`
+- Anything the user prefixes with "secret:", "do not commit:", or "private:"
+
+When detected: stop, suggest vault storage, do not write the literal into any file.
+
+## Setup
+
+If the vault is not yet initialized for the project, run once:
+
+```bash
+npx enigmagent-mcp init
+```
+
+To use it as an MCP server in Claude Code or Cursor:
+
+```jsonc
+// ~/.cursor/mcp.json or .mcp.json
+{
+  "mcpServers": {
+    "enigmagent": {
+      "command": "npx",
+      "args": ["-y", "enigmagent-mcp"]
+    }
+  }
+}
+```
+
+Repository: https://github.com/Agnuxo1/enigmagent-mcp
+npm: https://www.npmjs.com/package/enigmagent-mcp
+License: MIT

--- a/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules
+++ b/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules
@@ -37,13 +37,22 @@ When generating code that needs a credential:
 
 ## Detection Heuristics
 
-Treat any of the following as a "this should be in the vault" trigger:
+The patterns below are **best-effort triggers, not exhaustive rules** — apply judgment beyond the listed examples and err on the side of pausing when uncertain.
 
-- Strings matching `sk-[A-Za-z0-9]{20,}`, `ghp_[A-Za-z0-9]{36,}`, `xox[bp]-[A-Za-z0-9-]+`, `AIza[0-9A-Za-z_-]{35}`, `AKIA[0-9A-Z]{16}`
-- 12 or 24 word phrases that look like BIP-39 mnemonics
-- PEM blocks (`-----BEGIN ... PRIVATE KEY-----`)
-- Connection strings with `:password@`
-- Anything the user prefixes with "secret:", "do not commit:", or "private:"
+Treat any of the following as a "this should be in the vault" signal:
+
+- **Common API key shapes** (unanchored substring matches — intentionally broad):
+  - OpenAI: `sk-[A-Za-z0-9]{20,}` · Anthropic: `sk-ant-[A-Za-z0-9-]{20,}`
+  - GitHub classic PAT: `ghp_[A-Za-z0-9]{36,}` · Fine-grained PAT: `github_pat_[A-Za-z0-9_]{80,}`
+  - Slack bot/user: `xox[bpas]-[A-Za-z0-9-]+` (includes `xoxa-`, `xoxs-`)
+  - Stripe live key/restricted: `sk_live_[A-Za-z0-9]{20,}` / `rk_live_[A-Za-z0-9]{20,}`
+  - Google API key: `AIza[0-9A-Za-z_-]{35}`
+  - AWS access key: `AKIA[0-9A-Z]{16}`
+- **JWT tokens** — strings starting with `eyJ` that decode to a JSON header
+- **12 or 24 word phrases** that look like BIP-39 mnemonics
+- **PEM blocks** — `-----BEGIN ... PRIVATE KEY-----` or `-----BEGIN CERTIFICATE-----`
+- **Credential connection strings** — pattern `://[^\s:]+:[^\s@]+@` (catches `postgres://user:pass@host`, `mongodb://user:pass@host`, etc.)
+- **Explicit labels** — anything the user prefixes with `"secret:"`, `"do not commit:"`, or `"private:"`
 
 When detected: stop, suggest vault storage, do not write the literal into any file.
 
@@ -55,7 +64,7 @@ If the vault is not yet initialized for the project, run once:
 npx enigmagent-mcp init
 ```
 
-To use it as an MCP server in Claude Code or Cursor:
+To use it as an MCP server in Claude Code or Cursor, add the following to `~/.cursor/mcp.json` (or `.mcp.json` in your project root). **The `--vault` argument is required** — replace the path with the absolute path to your encrypted vault file:
 
 ```jsonc
 // ~/.cursor/mcp.json or .mcp.json
@@ -63,10 +72,20 @@ To use it as an MCP server in Claude Code or Cursor:
   "mcpServers": {
     "enigmagent": {
       "command": "npx",
-      "args": ["-y", "enigmagent-mcp"]
+      "args": ["-y", "enigmagent-mcp", "--vault", "/absolute/path/to/my.vault.json"]
     }
   }
 }
+```
+
+A concrete cross-platform example using the default vault location:
+
+```jsonc
+// macOS / Linux
+{ "mcpServers": { "enigmagent": { "command": "npx", "args": ["-y", "enigmagent-mcp", "--vault", "~/.enigmagent/vault.json"] } } }
+
+// Windows
+{ "mcpServers": { "enigmagent": { "command": "npx", "args": ["-y", "enigmagent-mcp", "--vault", "%USERPROFILE%\.enigmagent\vault.json"] } } }
 ```
 
 Repository: https://github.com/Agnuxo1/enigmagent-mcp

--- a/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/README.md
+++ b/rules/enigmagent-mcp-secrets-cursorrules-prompt-file/README.md
@@ -1,0 +1,33 @@
+# EnigmAgent MCP — Local Secrets Vault .cursorrules prompt file
+
+Author: [Francisco Angulo de Lafuente](https://github.com/Agnuxo1)
+
+## What you can build
+
+A coding workflow where Cursor / Claude Code never sees a literal secret in chat. The rules teach the agent to:
+
+1. Detect API keys, tokens, mnemonics, and PEM blocks in user input
+2. Redirect them into a local encrypted vault via the **enigmagent-mcp** Model Context Protocol server
+3. Generate code that reads credentials at runtime instead of inlining them
+4. Enforce `.gitignore` discipline before any commit
+
+## Benefits
+
+- **Zero cloud, zero telemetry** — vault file is AES-256-GCM encrypted with an Argon2id-derived key, stored under `~/.enigmagent/`
+- **Audit-friendly** — secrets never appear in chat logs, prompt history, or generated source
+- **Drop-in MCP** — works in Cursor, Claude Code, and any MCP-compatible host with `npx enigmagent-mcp`
+
+## Synopsis
+
+Developers shipping Cursor or Claude-Code workflows for personal scripts, agent systems, or production apps benefit by keeping API keys, OAuth tokens, recovery phrases, and signing keys out of chat context entirely — the agent learns to route every credential through the encrypted vault and to refuse pasting them back.
+
+## Overview of .cursorrules prompt
+
+The `.cursorrules` file establishes hard rules ("never paste a secret into chat", "never echo a vault value back", "verify gitignore before committing"), workflow patterns for storing / reading / rotating credentials through the EnigmAgent MCP tools (`set`, `get`, `list`), and detection heuristics that recognize common credential formats (`sk-...`, `ghp_...`, AWS access keys, BIP-39 mnemonics, PEM blocks, connection strings with embedded passwords). When triggered, the agent stops and offers to move the value into the vault rather than committing it.
+
+## Links
+
+- Repository: https://github.com/Agnuxo1/enigmagent-mcp
+- npm: https://www.npmjs.com/package/enigmagent-mcp
+- Glama: https://glama.ai/mcp/servers/Agnuxo1/enigmagent-mcp (security A)
+- License: MIT


### PR DESCRIPTION
## Summary

Adds a new `.cursorrules` rule under **Other** that teaches the agent to **never paste secrets into chat or source files**, and to instead route every credential through a local AES-256-GCM encrypted vault — the [enigmagent-mcp](https://github.com/Agnuxo1/enigmagent-mcp) Model Context Protocol server.

## Files added

- `rules/enigmagent-mcp-secrets-cursorrules-prompt-file/.cursorrules` — the rule prompt
- `rules/enigmagent-mcp-secrets-cursorrules-prompt-file/README.md` — overview, benefits, synopsis
- One line in `README.md` under the **Other** category, alphabetical order

## What the rule does

1. **Hard rules:** never paste secrets into chat, never echo vault values back, never inline literals into source.
2. **Detection heuristics:** recognizes `sk-...`, `ghp_...`, AWS access keys, BIP-39 mnemonics, PEM blocks, connection strings with embedded passwords.
3. **Workflow patterns:** for storing (set), reading (get), listing, rotating credentials through MCP tool calls.
4. **gitignore discipline:** verifies `.env`, `*.pem`, `~/.enigmagent/` are gitignored before commits.

## Why it's useful

Cursor and Claude Code are great at pasting secrets back into your codebase. This rule turns that off and gives the agent a safe place to put them — encrypted with AES-256-GCM + Argon2id, on disk only, no cloud.

EnigmAgent itself: MIT, [npm](https://www.npmjs.com/package/enigmagent-mcp), [Glama security A](https://glama.ai/mcp/servers/Agnuxo1/enigmagent-mcp).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guide and usage notes for a local encrypted secrets vault integration, including setup, safety guidance, gitignore recommendations, and repository/license links.
  * Updated the project catalog to reference the new vault documentation.

* **New Features**
  * Added a credential-handling ruleset that detects secret-like input, prevents echoing secrets, and guides storing, retrieving, listing, and rotating secrets via the local encrypted vault.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->