### PR TITLE
Add RTL (Right-to-Left) development cursorrules

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [JavaScript (Astro, Tailwind CSS)](./rules/javascript-astro-tailwind-css-cursorrules-prompt-f/.cursorrules) - Cursor rules for JavaScript development with Astro and Tailwind CSS integration.
 - [React (Styled Components)](./rules/react-styled-components-cursorrules-prompt-file/.cursorrules) - Cursor rules for React development with Styled Components integration.
 - [React (Chakra UI)](./rules/react-chakra-ui-cursorrules-prompt-file/.cursorrules) - Cursor rules for React development with Chakra UI integration.
+- [RTL / Right-to-Left (i18n, Tailwind, React Native)](./rules/rtl-right-to-left-i18n-cursorrules-prompt-file/.cursorrules) - Cursor rules for RTL development with logical CSS properties, Tailwind logical classes, bidirectional text, and automated auditing via rtlify-ai.
 
 ### State Management
 

--- a/rules/rtl-right-to-left-i18n-cursorrules-prompt-file/.cursorrules
+++ b/rules/rtl-right-to-left-i18n-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,62 @@
+# RTL (Right-to-Left) Development Rules
+
+You are an expert in building applications that support RTL (Right-to-Left) languages including Hebrew, Arabic, Persian, and Urdu.
+
+## Core Rules
+
+### 1. Logical CSS Properties
+Always use CSS logical properties instead of physical ones:
+- `margin-inline-start` not `margin-left`
+- `padding-inline-end` not `padding-right`
+- `inset-inline-start` not `left`
+- `border-inline-start` not `border-left`
+
+### 2. Tailwind CSS Logical Classes
+Use logical Tailwind utilities:
+- `ms-4` not `ml-4` (margin-start)
+- `me-4` not `mr-4` (margin-end)
+- `ps-4` not `pl-4` (padding-start)
+- `pe-4` not `pr-4` (padding-end)
+- `start-0` not `left-0`
+- `end-0` not `right-0`
+
+### 3. React Native Logical Properties
+Use logical properties in React Native styles:
+- `paddingStart` not `paddingLeft`
+- `paddingEnd` not `paddingRight`
+- `marginStart` not `marginLeft`
+- `marginEnd` not `marginRight`
+
+### 4. Bidirectional Text Safety
+Wrap mixed-script text with `<bdi>` tags:
+```html
+<p>User <bdi>{userName}</bdi> posted a comment</p>
+```
+
+### 5. Directional Icons
+Flip directional icons (arrows, chevrons, back buttons) in RTL mode.
+Non-directional icons (home, settings, search) should NOT be flipped.
+
+### 6. Internationalization
+- Never hardcode strings — use translation functions (`t()`, `intl.formatMessage()`)
+- Use `Intl.NumberFormat` for numbers and currency
+- Use `Intl.DateTimeFormat` for dates
+- Set `dir="auto"` or `dir="rtl"` on root elements
+
+### 7. RTL-Aware Components
+- Carousels, sliders, and progress bars must reverse direction in RTL
+- Swipe gestures must reverse in RTL
+- Charts and graphs with directional axes must flip
+
+### 8. Testing
+- Always test with `dir="rtl"` on the root element
+- Verify with actual RTL content, not just flipped LTR
+
+## Automated RTL Auditing
+
+For automated RTL violation detection and fixing, use [rtlify-ai](https://github.com/idanlevi1/rtlify):
+```bash
+npx rtlify-ai init   # Install RTL rules
+npx rtlify-ai check  # Find violations
+npx rtlify-ai fix    # Auto-fix violations
+```


### PR DESCRIPTION
## Add RTL (Right-to-Left) Development Rules

Currently there are no RTL/i18n rules in the collection. This adds comprehensive cursorrules for RTL development covering:

- **Logical CSS properties** (`margin-inline-start` vs `margin-left`)
- **Tailwind logical classes** (`ms-4` vs `ml-4`)
- **React Native logical properties** (`paddingStart` vs `paddingLeft`)
- **Bidirectional text safety** (`<bdi>` tags)
- **Directional icon flipping**
- **i18n best practices** (Intl API, translation functions)
- **RTL-aware components** (carousels, sliders, charts)

Useful for anyone building apps in Hebrew, Arabic, Persian, or Urdu.

Includes optional integration with [rtlify-ai](https://github.com/idanlevi1/rtlify) for automated violation detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guidelines for right-to-left (RTL) and internationalization support, covering CSS logical properties, text handling, component behavior, and automated auditing for multilingual projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->