### PR TITLE
feat: add AgentsMesh cursor rules for universal AI config sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,9 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 ### Utilities
 
+- [AgentsMesh (AI Config Sync)](./rules/agentsmesh-ai-config-sync-cursorrules-prompt-file/.cursorrules) - Cursor rules for projects using AgentsMesh — the universal config sync CLI that maintains AI coding agent rules, commands, agents, skills, and MCP servers in a single canonical source and generates native configs for 18+ tools including Cursor, Claude Code, Copilot, and Gemini CLI.
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
 - [Helium MCP (news, bias, markets, options, memes)](./rules/helium-mcp-cursorrules-prompt-file/.cursorrules) - Cursor rules for using Helium MCP in Cursor: streamable HTTP setup, when to call each hosted tool (`search_news`, `search_balanced_news`, `get_source_bias`, `get_bias_from_url`, `get_all_source_biases`, `get_ticker`, `get_option_price`, `get_top_trading_strategies`, `search_memes`), query discipline, and rate-limit awareness. See also `./rules/helium-mcp-cursorrules-prompt-file/README.md`.
-- [AgentsMesh (AI Config Sync)](./rules/agentsmesh-ai-config-sync-cursorrules-prompt-file/.cursorrules) - Cursor rules for projects using AgentsMesh — the universal config sync CLI that maintains AI coding agent rules, commands, agents, skills, and MCP servers in a single canonical source and generates native configs for 18+ tools including Cursor, Claude Code, Copilot, and Gemini CLI.
 
 ## Directories
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
 - [Helium MCP (news, bias, markets, options, memes)](./rules/helium-mcp-cursorrules-prompt-file/.cursorrules) - Cursor rules for using Helium MCP in Cursor: streamable HTTP setup, when to call each hosted tool (`search_news`, `search_balanced_news`, `get_source_bias`, `get_bias_from_url`, `get_all_source_biases`, `get_ticker`, `get_option_price`, `get_top_trading_strategies`, `search_memes`), query discipline, and rate-limit awareness. See also `./rules/helium-mcp-cursorrules-prompt-file/README.md`.
+- [AgentsMesh (AI Config Sync)](./rules/agentsmesh-ai-config-sync-cursorrules-prompt-file/.cursorrules) - Cursor rules for projects using AgentsMesh — the universal config sync CLI that maintains AI coding agent rules, commands, agents, skills, and MCP servers in a single canonical source and generates native configs for 18+ tools including Cursor, Claude Code, Copilot, and Gemini CLI.
 
 ## Directories
 

--- a/rules/agentsmesh-ai-config-sync-cursorrules-prompt-file/.cursorrules
+++ b/rules/agentsmesh-ai-config-sync-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,72 @@
+# AgentsMesh — Universal AI Agent Config Sync
+
+You are working in a project that uses AgentsMesh to manage AI coding agent
+configurations from a single canonical source.
+
+## Key Concepts
+
+- The `.agentsmesh/` directory is the single source of truth for all AI tool configs.
+- Running `agentsmesh generate` produces native config files for every target tool
+  (Cursor, Claude Code, Copilot, Gemini CLI, Windsurf, Codex CLI, etc.).
+- Running `agentsmesh import --from <target>` brings existing tool configs back
+  into canonical form without loss.
+- Generated files are artifacts — never edit them directly. Always edit canonical
+  files in `.agentsmesh/` and regenerate.
+
+## Project Structure
+
+```
+.agentsmesh/
+├── rules/
+│   ├── _root.md          # Root rules applied globally
+│   └── *.md              # Scoped rules (matched by globs in frontmatter)
+├── commands/
+│   └── *.md              # Slash commands
+├── agents/
+│   └── *.md              # Agent personas
+├── skills/
+│   └── <name>/SKILL.md   # Skills with optional bundled assets
+├── mcp.json              # MCP server configurations
+├── hooks.yaml            # Event-driven hooks
+├── permissions.yaml      # Tool permission policies
+└── ignore                # Patterns to exclude from AI context
+```
+
+## Workflow Rules
+
+1. **Never edit generated files** — files outside `.agentsmesh/` that are managed
+   by agentsmesh (e.g., `.cursor/rules/`, `.claude/`, `.github/copilot-instructions.md`)
+   are regenerated on each `agentsmesh generate` run.
+2. **Edit canonical sources** — make all changes in `.agentsmesh/` then run
+   `agentsmesh generate` to propagate.
+3. **Use `agentsmesh diff`** to preview what generate would change before running it.
+4. **Use `agentsmesh check`** in CI to ensure generated files are not stale.
+5. **Use `agentsmesh lint`** to validate canonical configs and catch silent-drop
+   warnings before generating.
+
+## CLI Commands Reference
+
+- `agentsmesh init` — Scaffold `.agentsmesh/` directory and config files
+- `agentsmesh generate` — Write native configs from canonical sources
+- `agentsmesh import --from <target>` — Read existing tool configs into canonical form
+- `agentsmesh diff` — Preview pending changes
+- `agentsmesh check` — CI gate (exit non-zero on drift)
+- `agentsmesh lint` — Validate canonical config
+- `agentsmesh watch` — Auto-regenerate on file changes
+- `agentsmesh convert --from <src> --to <dst>` — Convert between tool formats
+- `agentsmesh install <source>` — Add community packs
+- `agentsmesh matrix` — Show supported tools and feature coverage
+
+## When Modifying AI Rules or Config
+
+- Add or edit rules in `.agentsmesh/rules/` using markdown with optional
+  frontmatter for globs (`globs: ["src/**/*.ts"]`) and `alwaysApply: true/false`.
+- The `_root.md` file contains project-wide rules applied to all contexts.
+- After any change, run `agentsmesh generate` and commit both canonical and
+  generated files together.
+
+## Configuration File
+
+`agentsmesh.yaml` at the project root selects which targets to generate for
+and which features to enable. `agentsmesh.local.yaml` provides local overrides
+that should be gitignored.

--- a/rules/agentsmesh-ai-config-sync-cursorrules-prompt-file/README.md
+++ b/rules/agentsmesh-ai-config-sync-cursorrules-prompt-file/README.md
@@ -1,0 +1,21 @@
+# AgentsMesh Cursor Rules
+
+Cursor rules for projects using [AgentsMesh](https://github.com/sampleXbro/agentsmesh) — the universal config sync CLI for AI coding agents.
+
+## What This Covers
+
+- Working with the `.agentsmesh/` canonical source directory
+- Understanding the generate/import workflow
+- CLI commands reference for common operations
+- Rules for never editing generated files directly
+- CI drift detection with `agentsmesh check`
+
+## Links
+
+- **GitHub**: [github.com/sampleXbro/agentsmesh](https://github.com/sampleXbro/agentsmesh)
+- **npm**: [npmjs.com/package/agentsmesh](https://www.npmjs.com/package/agentsmesh)
+- **Docs**: [samplexbro.github.io/agentsmesh](https://samplexbro.github.io/agentsmesh/)
+
+## Author
+
+[Serhii Zhabskyi](https://github.com/sampleXbro)


### PR DESCRIPTION
## Summary

Adds [AgentsMesh](https://github.com/sampleXbro/agentsmesh) cursor rules to the **Utilities** category.

AgentsMesh is an open-source CLI that lets you maintain a single canonical source (`.agentsmesh/`) for AI coding agent rules, commands, agents, skills, MCP servers, hooks, and permissions — then auto-generates native config files for 18+ tools including Cursor, Claude Code, GitHub Copilot, Gemini CLI, Windsurf, Codex CLI, and more.

### What's included

- **`.cursorrules` file** with practical rules for working with agentsmesh-managed projects in Cursor:
  - Project structure overview (`.agentsmesh/` directory layout)
  - Workflow rules (edit canonical sources, never edit generated files)
  - CLI commands reference (`generate`, `import`, `diff`, `check`, `lint`, `watch`)
  - Configuration guidance for rules, commands, agents, and skills
- **README.md** in the rules folder with links and description
- **README.md update** with entry under Utilities section

### Links

- GitHub: https://github.com/sampleXbro/agentsmesh
- npm: https://www.npmjs.com/package/agentsmesh
- Docs: https://samplexbro.github.io/agentsmesh/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for managing AI tool configurations: project layout, workflow rules, CLI commands, and recommended modification/regeneration workflows
  * Added a supporting README detailing scope, external resources, and authorship
  * Updated Utilities section with a new reference for "AgentsMesh (AI Config Sync)"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->