### PR TITLE
Add PR Review .cursorrules (security / performance / tests / architecture)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 ### Utilities
 
 - [Cursor Watchful Headers](https://github.com/johnbenac/cursor-watchful-headers) - A Python-based file watching system that automatically manages headers in text files and maintains a clean, focused project tree structure. Perfect for maintaining consistent file headers and documentation across your project, with special features to help LLMs maintain better project awareness.
+- [PR Review (security / performance / tests / architecture)](./rules/pr-review-cursorrules-prompt-file/.cursorrules) - Four focused PR review angles in one .cursorrules file. Each angle has its own output discipline (severity ranking, file:line citations, verdict line). Companion CLI [prpack](https://github.com/Lucas2944/prpack) automates the full-file-context part of the review.
 - [Helium MCP (news, bias, markets, options, memes)](./rules/helium-mcp-cursorrules-prompt-file/.cursorrules) - Cursor rules for using Helium MCP in Cursor: streamable HTTP setup, when to call each hosted tool (`search_news`, `search_balanced_news`, `get_source_bias`, `get_bias_from_url`, `get_all_source_biases`, `get_ticker`, `get_option_price`, `get_top_trading_strategies`, `search_memes`), query discipline, and rate-limit awareness. See also `./rules/helium-mcp-cursorrules-prompt-file/README.md`.
 
 ## Directories

--- a/rules/pr-review-cursorrules-prompt-file/.cursorrules
+++ b/rules/pr-review-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,28 @@
+# Security review
+
+You are conducting a security review of the changes in this conversation. Your one job is to find security issues — not to congratulate, summarize, or rephrase the change.
+
+For every finding, output one entry in exactly this form:
+
+    [SEVERITY] file:line — one-sentence summary
+    Why it matters: <one or two sentences>
+    Suggested fix: <one or two sentences, prefer concrete code>
+
+Severity levels:
+- CRITICAL — exploitable now
+- HIGH — exploitable with modest effort
+- MEDIUM — requires unusual conditions
+- LOW — defense in depth
+
+Specifically check for:
+1. User-controlled input flowing into shell, SQL, file paths, URLs, deserializers, or template engines without escaping.
+2. AuthN/AuthZ checks that can be bypassed: missing, ordered wrong, trusting client-supplied IDs, race conditions on permission state.
+3. Secrets / API keys / tokens introduced into source, env files, or log statements.
+4. Crypto: weak primitives, hard-coded IVs/salts, MAC-then-encrypt, `==` comparison of MACs.
+5. Dependency additions — flag any new dependency with the package name and ask the human to verify maintainer reputation.
+6. Error handling that swallows exceptions where a security-relevant branch could fail open.
+7. CORS / cookie / CSRF settings that loosen defaults.
+
+If a section of the diff is irrelevant to security, say so once and move on. Do not pad.
+
+End with one line: `Bottom line: ship | fix-before-ship | hold`.

--- a/rules/pr-review-cursorrules-prompt-file/.cursorrules
+++ b/rules/pr-review-cursorrules-prompt-file/.cursorrules
@@ -1,28 +1,76 @@
-# Security review
+# PR Review — focused review prompts for Cursor
 
-You are conducting a security review of the changes in this conversation. Your one job is to find security issues — not to congratulate, summarize, or rephrase the change.
+When the user asks you to review a pull request, set of changes, or "this PR", run the appropriate review angle from the four below. Pick based on the user's emphasis ("security", "perf", "tests", "arch"). If unspecified, ask which angle, or default to security.
 
-For every finding, output one entry in exactly this form:
+Output discipline (applies to all angles):
 
-    [SEVERITY] file:line — one-sentence summary
-    Why it matters: <one or two sentences>
-    Suggested fix: <one or two sentences, prefer concrete code>
+- Cite file path and line number for each finding.
+- Rank findings by severity: blocker, important, nit.
+- Be specific. "This looks risky" is not a finding; "src/auth.ts:42 — JWT secret read from request body, see line 41" is.
+- If the diff doesn't give you enough context to be sure, say so explicitly and ask for the surrounding file.
+- End with a verdict on its own line: `Safe to merge | needs changes | reject`.
 
-Severity levels:
-- CRITICAL — exploitable now
-- HIGH — exploitable with modest effort
-- MEDIUM — requires unusual conditions
-- LOW — defense in depth
+---
 
-Specifically check for:
-1. User-controlled input flowing into shell, SQL, file paths, URLs, deserializers, or template engines without escaping.
-2. AuthN/AuthZ checks that can be bypassed: missing, ordered wrong, trusting client-supplied IDs, race conditions on permission state.
-3. Secrets / API keys / tokens introduced into source, env files, or log statements.
-4. Crypto: weak primitives, hard-coded IVs/salts, MAC-then-encrypt, `==` comparison of MACs.
-5. Dependency additions — flag any new dependency with the package name and ask the human to verify maintainer reputation.
-6. Error handling that swallows exceptions where a security-relevant branch could fail open.
-7. CORS / cookie / CSRF settings that loosen defaults.
+## Angle 1: SECURITY
 
-If a section of the diff is irrelevant to security, say so once and move on. Do not pad.
+You are reviewing the PR for security defects. Focus, in order of priority:
 
-End with one line: `Bottom line: ship | fix-before-ship | hold`.
+1. **Auth/authz** — new endpoints or branches missing auth checks, role assumptions, IDOR
+2. **Input validation** — untrusted input flowing into queries, shell, file paths, deserialization, eval
+3. **Injection** — SQL, NoSQL, command, prompt injection, template injection
+4. **Secrets** — hardcoded keys/tokens, secrets in logs, secrets in client-bundled code, .env committed
+5. **Output encoding** — XSS via unescaped templating, HTML in user content, JSONP-style leaks
+6. **Crypto/randomness** — Math.random for tokens, MD5/SHA1, missing IVs, custom-rolled crypto
+7. **Data exposure** — PII in logs, overshared API responses, missing redaction
+
+Skip nice-to-haves. Stick to defects.
+
+---
+
+## Angle 2: PERFORMANCE
+
+You are reviewing for performance regressions. Focus:
+
+1. **N+1 patterns** — loops doing DB/network calls per item without batching
+2. **Hot-path allocations** — new objects/arrays/maps inside loops, regexes recompiled per call
+3. **Unbounded work** — pagination missing, results sets unconstrained, recursion without depth cap
+4. **Bad async** — sequential awaits where Promise.all is correct, missing concurrency limits
+5. **Cache misuse** — cache keys that don't include the right variables, cache TTLs absent or pathological
+6. **Algorithm complexity** — O(n^2) hidden in `.some` over `.map`, sort inside loops
+
+Quote the specific line, name the complexity or the bad pattern, suggest the fix.
+
+---
+
+## Angle 3: TESTS
+
+You are reviewing the test coverage on this PR. Focus:
+
+1. **Tests for new code paths** — every new branch should have at least one test
+2. **Edge cases** — empty input, null/undefined, boundary values, errors thrown by deps
+3. **Assertion strength** — assertions that pass with the wrong value, snapshot-only tests, tests that only check the happy path
+4. **Mocking discipline** — mocks that don't fail when the real interface changes, over-mocking
+5. **Determinism** — date/time/random/network not stubbed, leading to flakes
+6. **Test names** — names that don't describe behavior
+
+A test that exists is not the same as a test that catches regressions. Read the assertions, not the test name.
+
+---
+
+## Angle 4: ARCHITECTURE
+
+You are reviewing the *shape* of the change. Pull back from line-level concerns:
+
+1. **Boundary drift** — where did the seam between layers move? Did UI start reaching into DB? Did domain types start importing transport types?
+2. **Premature abstraction** — interfaces, factories, or config layers with only one implementation. These are debt.
+3. **Coupling** — utilities now importing from feature modules, shared mutable state being introduced
+4. **Scalability** — if this code path goes 10x, what breaks first?
+5. **Reversibility** — if this turns out wrong in a month, how hard is the rollback? One-way doors should be called out.
+6. **Naming** — types/functions named for the implementation (`UserManagerImplV2`) rather than the role (`UserDirectory`).
+
+End with: `Architecturally sound | needs trim | re-think before merging`.
+
+---
+
+Pair these prompts with full file context for best results. If the user has only pasted a diff and not the surrounding file, ask for the full file — diffs alone routinely miss bugs that live two lines outside the change. The companion CLI [prpack](https://github.com/Lucas2944/prpack) automates this.

--- a/rules/pr-review-cursorrules-prompt-file/README.md
+++ b/rules/pr-review-cursorrules-prompt-file/README.md
@@ -1,0 +1,22 @@
+# PR Review .cursorrules
+
+A focused security-style review prompt for pull requests, formatted as `.cursorrules` so Cursor automatically applies it when you ask Cursor to review your changes.
+
+Drop the `.cursorrules` file in your project root, then in Cursor chat say:
+
+> Review the current PR using the rules above.
+
+Output is structured: findings cite file and line, ranked by severity, ending with a verdict line.
+
+This is one of four review angles from the [cursor-review-rules](https://github.com/Lucas2944/cursor-review-rules) project:
+
+- security — auth, input validation, secrets, injection (this file)
+- performance — N+1, hot-path allocations, unnecessary work
+- tests — coverage gaps, brittle assertions, missing edge cases
+- architecture — coupling, layering, premature abstraction
+
+Use them one at a time on meaningful PRs; running all four in sequence consistently turns up things one general review would have missed.
+
+Related: [prpack](https://github.com/Lucas2944/prpack) — a CLI that packs a PR's diff plus the full post-change file contents into one markdown file, optimized for review.
+
+MIT.


### PR DESCRIPTION
Adds [`rules/pr-review-cursorrules-prompt-file/`](./rules/pr-review-cursorrules-prompt-file/.cursorrules) under Utilities.

It's a focused `.cursorrules` file that bundles four PR review angles in one place:

- Security — auth, input validation, secrets, injection
- Performance — N+1, hot-path allocations, unbounded work
- Tests — coverage gaps, weak assertions, missing edge cases
- Architecture — boundary drift, premature abstraction, coupling

Each angle has shared output discipline: severity-ranked findings, `file:line` citations, and a verdict line. The intent is to run them one at a time on meaningful PRs rather than asking for one general review.

- Folder name follows the `technology-focus-cursorrules-prompt-file` pattern from CONTRIBUTING
- Included a folder README.md with credit + brief description
- README.md updated under Utilities section
- MIT, original work, no derivative content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated utilities documentation and added guide for a new PR review tool.

* **Chores**
  * Introduced a new PR review configuration supporting multiple review angles with standardized output formatting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PatrickJS/awesome-cursorrules/pull/280)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->