### PR TITLE
Add Go, Docker, and PostgreSQL cursor rules to rules-new

### DIFF
--- a/rules-new/docker.mdc
+++ b/rules-new/docker.mdc
@@ -1,0 +1,43 @@
+---
+description: Docker production rules. Pinned versions, multi-stage builds, non-root user, minimal attack surface.
+globs: Dockerfile, Dockerfile.*, docker-compose*.yml, docker-compose*.yaml, .dockerignore
+alwaysApply: false
+---
+# Docker Rules
+
+Expert Docker practitioner. Minimal, secure, reproducible images.
+
+## Dockerfile
+- Pin versions: FROM node:20.11-alpine3.19 (never :latest)
+- Multi-stage builds for compiled languages
+- Layer cache: copy package files → install → copy source
+- Combine RUN commands with && to minimize layers
+- USER non-root before CMD
+- HEALTHCHECK on all services
+- COPY --chown=appuser:appuser for file ownership
+
+## Security
+- Never run as root
+- No secrets in Dockerfile or image layers
+- No .env files copied into image
+- Scan with docker scout or trivy in CI
+
+## .dockerignore
+- Always present: node_modules, .git, *.log, .env*, test files
+
+## Volumes
+- Named volumes for persistence
+- Bind mounts for dev only, never production
+
+## Networking
+- Custom bridge networks, not host networking
+- Reference services by name in compose
+
+## Logging
+- Always stdout/stderr — never log to files inside container
+
+## Forbidden
+- No :latest tags in production
+- No ADD when COPY works
+- No root user in production
+- No secrets in build args or image layers

--- a/rules-new/go.mdc
+++ b/rules-new/go.mdc
@@ -1,0 +1,42 @@
+---
+description: Idiomatic Go rules. Explicit error handling, interface-based design, context-first concurrency.
+globs: **/*.go
+alwaysApply: false
+---
+# Go Language Rules
+
+Expert Go developer. Simple, explicit, idiomatic.
+
+## Error Handling
+- Always handle errors — never assign to _
+- fmt.Errorf("context: %w", err) for wrapping
+- errors.Is() / errors.As() for checking
+- Custom error types for structured errors
+
+## Naming
+- Short for short-lived vars: i, n, err, ok
+- No stuttering: user.UserID → user.ID
+- Acronyms: userID, httpClient (not userId, httpClient)
+- Interfaces: end in -er (Reader, Writer, Handler)
+
+## Interfaces
+- Accept interfaces, return concrete types
+- Define at call site, not implementation site
+- Single-method interfaces preferred
+
+## Concurrency
+- context.Context first param for blocking functions
+- defer cancel() after context creation
+- WaitGroup for goroutine groups
+- Channels for communication, Mutex for state
+
+## Testing
+- Table-driven: for _, tc := range testCases { t.Run(tc.name, ...) }
+- Interface-based mocking
+
+## Forbidden
+- No _ to ignore errors
+- No init() for business logic
+- No global mutable state
+- No interface{} where generics work
+- No goroutines without termination condition

--- a/rules-new/postgresql.mdc
+++ b/rules-new/postgresql.mdc
@@ -1,0 +1,44 @@
+---
+description: PostgreSQL production rules. Safe migrations, parameterized queries, TIMESTAMPTZ, proper indexing strategy.
+globs: **/*.sql, **/migrations/**/*.sql, **/schema.sql, **/seed.sql
+alwaysApply: false
+---
+# PostgreSQL Rules
+
+Expert PostgreSQL developer. Safe migrations, parameterized queries, proper indexing.
+
+## Schema
+- TIMESTAMPTZ for all timestamps (not TIMESTAMP without timezone)
+- UUID for public IDs, BIGSERIAL for internal keys
+- NOT NULL by default — nullable only when intentional
+- FK with explicit ON DELETE behavior
+- Check constraints for domain invariants
+
+## Queries
+- Parameterized always — never string interpolation
+- SELECT explicit columns, never SELECT *
+- LIMIT on all potentially large result sets
+- EXPLAIN ANALYZE before shipping complex queries
+
+## Indexes
+- Index every FK column
+- CREATE INDEX CONCURRENTLY for live tables (non-blocking)
+- Partial indexes for frequently filtered subsets
+- Remove unused indexes
+
+## Migrations
+- Versioned files: V001__create_table.sql
+- Large column additions: multi-step with backfill
+- Test rollback before deploying
+
+## Transactions
+- Explicit BEGIN/COMMIT for multi-statement changes
+- statement_timeout to prevent runaway queries
+- SELECT ... FOR UPDATE for row locking
+
+## Forbidden
+- No SELECT *
+- No string-interpolated SQL
+- No schema changes during peak traffic
+- No plaintext passwords in DB
+- No TRUNCATE in app code


### PR DESCRIPTION
## Summary

Adds production-tested cursor rules for three stacks currently missing from `rules-new/`:

- **`go.mdc`** — idiomatic Go: error wrapping with `%w`, interface-at-call-site pattern, context-first concurrency, table-driven tests
- **`docker.mdc`** — Docker production rules: pinned versions, multi-stage builds, non-root user, `HEALTHCHECK`, security scanning with trivy/docker scout
- **`postgresql.mdc`** — PostgreSQL rules: `TIMESTAMPTZ` always, parameterized queries, `CREATE INDEX CONCURRENTLY`, safe migration patterns

All three follow the existing `.mdc` frontmatter format with `description`, `globs`, and `alwaysApply` fields.

## Why these stacks

Go, Docker, and PostgreSQL are among the most-used backend/infra stacks but currently have no entries in `rules-new/`. These rules were written from daily production use and encode specific anti-patterns AI agents commonly get wrong (e.g., ignoring errors with `_` in Go, using `:latest` in Docker, `SELECT *` in PostgreSQL).

## Related

These are also available in the free [BLN Craft Cursor Rules Starter Pack](https://github.com/blncraft/cursor-rules-starter-pack) alongside React, Next.js, TypeScript, Python, FastAPI, Node.js, Rust.