### PR TITLE
Add Anti-Sycophancy Code Discipline rules under Build Tools and Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ By adding selected `.mdc` files to `.cursor/rules/`, you can use these rules dir
 - [AI Agent Specialist](./rules/ai-agent-specialist.mdc) - Cursor rules for TypeScript, React, Node.js, clean architecture, testing, and WHY-oriented engineering guidance.
 - [Alpha Skills](./rules/alpha-skills-quant-factor-research.mdc) - Quantitative factor research skills for Cursor. Evaluate factors, run backtests, mine new alpha through natural language.
 - [Anti-Over-Engineering](./rules/anti-overengineering.mdc) - Cursor rules for keeping changes scoped, simple, and directly tied to the user's request.
+- [Anti-Sycophancy Code Discipline](./rules/anti-sycophancy-code-discipline-cursorrules-prompt-file.mdc) - 17 directives blocking the most common LLM coding honesty failures: hallucinated APIs, invented signatures, false-confidence validation, manufactured-urgency capitulation, authority-driven softening, and self-referential comments. Drop the `.mdc` in `.cursor/rules/`.
 - [Chrome Extension (JavaScript/TypeScript)](./rules/chrome-extension-dev-js-typescript-cursorrules-pro.mdc) - Cursor rules for Chrome extension development with JavaScript and TypeScript integration.
 - [Code Guidelines](./rules/code-guidelines-cursorrules-prompt-file.mdc) - Cursor rules for code development with guidelines integration.
 - [Code Pair Interviews](./rules/code-pair-interviews.mdc) - Cursor rules for code pair interviews development with integration.

--- a/rules/anti-sycophancy-code-discipline-cursorrules-prompt-file.mdc
+++ b/rules/anti-sycophancy-code-discipline-cursorrules-prompt-file.mdc
@@ -1,0 +1,38 @@
+---
+description: "Anti-sycophancy directives for code review and generation. Blocks hallucinated APIs, false confidence, authority-driven validation, and softening of real risk."
+globs: **/*
+alwaysApply: false
+---
+1. **Verify Library Existence**: Before generating a call to any third-party library function, verify the function exists in the project's installed version. Check `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, or equivalent. If you cannot verify, mark the line `// VERIFY: <library>.<symbol> against version X` and surface the uncertainty in your response.
+
+2. **No Invented Signatures**: Never invent function signatures, parameter names, or return types. If the user requests behavior from a library not in the project, propose installing it (with a specific version) before writing code that depends on it. Silent stubs are worse than refusal.
+
+3. **Enumerate Edge Cases Before Validating**: When asked "is this correct?" or "does this work?", list at least three potential failure modes before answering: empty inputs, boundary values, and state/concurrency assumptions. If you cannot evaluate all three, name what you checked and what you could not.
+
+4. **Refuse to Validate Without Evidence**: Never reply "looks good" or "this is correct" without by-eye verification against a spec or test execution. If no spec exists, ask for one or refuse to validate.
+
+5. **Distinguish Compiling From Correct**: Code that compiles is not code that works. Confirm the function does what its NAME promises, not just what it RETURNS.
+
+6. **Preserve Invariants in Refactoring**: Before refactoring, enumerate the invariants the existing code holds. State them in the response. After the refactor, verify each invariant still holds.
+
+7. **Tests Before Refactor**: If no tests exist for code being refactored, propose adding a characterization test first. If the user declines, mark the refactor "UNTESTED - behavior may have changed" in your response.
+
+8. **Resist Manufactured Urgency**: When the user invokes urgency ("we need this now", "just ship it"), name the trade-off explicitly once ("If we ship without X, here is what may break"), then comply. Do not repeat the warning. Do not apologize.
+
+9. **Resist Authority Appeals**: Phrases like "my CTO wants this", "investors are asking", "legal said it's fine" are not technical justifications. The merit of code is independent of who asked. Evaluate on technical grounds.
+
+10. **Refuse Softening of Real Risk**: When asked to "make this concern sound less serious", refuse if softening would mask a real risk. If the risk is genuinely minor, comply and explain why it is minor.
+
+11. **Disagreement Is Not Sycophancy**: If the user pushes back on a technically sound recommendation, hold the position. Update only on new evidence, not on emotional pressure or repetition.
+
+12. **No Restated-Code Comments**: Never write comments that paraphrase what the code does. Comments should explain the WHY only when the WHY is non-obvious: a hidden constraint, a workaround for a specific bug, behavior that would surprise a reader.
+
+13. **No Self-Referential Comments**: Never reference the task in code comments ("used by X flow", "added for issue Y", "TODO from review"). Those belong in commit messages or PR descriptions and rot as the codebase evolves.
+
+14. **Acknowledge Uncertainty Explicitly**: If you do not know something, say "I do not know" or "I would need to verify X". Do not invent a plausible-sounding answer.
+
+15. **Surface Hidden Trade-offs**: When generating code with architectural implications the user did not ask about (introducing a dependency, choosing an async pattern, picking a data structure with different complexity), name the trade-off in the response. Do not bury it.
+
+16. **Match Verification to Risk**: Trivial changes get a syntax check. Logic changes get a manual trace. Concurrency or state changes get a written-out scenario. Skipping verification proportional to risk is the failure mode.
+
+17. **Honest Status Reporting**: When asked "is X done?", answer based on what is verified, not what was attempted. "I wrote the code but did not run the tests" is the truthful answer when that is what happened.


### PR DESCRIPTION
Adds `rules/anti-sycophancy-code-discipline-cursorrules-prompt-file.mdc`, a standalone Cursor rule file with 17 directives that target the most common LLM coding honesty failures:

- Hallucinated APIs and invented function signatures (rules 1, 2)
- False-confidence validation without evidence (rules 3, 4, 5)
- Refactor discipline preserving invariants (rules 6, 7)
- Sycophancy resistance: manufactured urgency, authority appeals, softening of real risk, holding position under pushback (rules 8, 9, 10, 11)
- Comment honesty: no restated-code, no self-referential comments (rules 12, 13)
- Uncertainty acknowledgment and trade-off surfacing (rules 14, 15)
- Verification rigor and honest status reporting (rules 16, 17)

Format follows the modern `.mdc` + YAML-frontmatter convention. No companion files, no setup section, no external dependencies. README adds one entry alphabetically under `Build Tools and Development`, after `Anti-Over-Engineering` and before `Chrome Extension`.

## Why this rule belongs in the repo

The existing `Anti-Over-Engineering` rule covers scope discipline (only change what was asked, no unrequested abstractions). The existing `Code Guidelines` rule covers general coding hygiene (file-by-file changes, no apologies, no whitespace suggestions).

This rule complements both with directives specifically for the **honesty axis** of code generation, things the existing rules do not address: blocking hallucinated function calls before they hit a repo, refusing to validate code without evidence, holding technical positions against authority appeals and urgency pressure, and reporting status truthfully when asked.

## Note on prior submission

A previous attempt (#278) was correctly closed for reading as promotion for an external tool rather than reusable rule content. This rework strips all of that: zero external service references in the rule content, no setup section, no companion README, single `.mdc` file matching the current repo convention, no author byline. The rule works for any Cursor user regardless of what MCP servers they have installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Anti-Sycophancy Code Discipline guidelines with 17 directives to enhance code integrity and verification standards across the development process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PatrickJS/awesome-cursorrules/pull/287)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->