### PR TITLE
[codex] add state management cursor rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ By adding selected `.mdc` files to `.cursor/rules/`, you can use these rules dir
 - [React (MobX)](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/react-mobx-cursorrules-prompt-file.mdc) - React development with MobX integration.
 - [React (React Query)](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/react-query-cursorrules-prompt-file.mdc) - React development with React Query integration.
 - [React (TanStack Router + Query)](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/react-tanstack-router-query-cursorrules-prompt-file.mdc) - React SPAs combining TanStack Router v1 and TanStack Query v5 for zero-loading-spinner routing and type-safe server state.
-- [React (Zustand)](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/react-zustand-cursorrules-prompt-file.mdc) - React state management with Zustand stores, selectors, middleware, persistence, and testing.
+- [React (Zustand)](rules/react-zustand-cursorrules-prompt-file.mdc) - React state management with Zustand stores, selectors, middleware, persistence, and testing.
 - [TanStack Query v5](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/tanstack-query-v5-cursorrules-prompt-file.mdc) - Query options, query key factories, mutations, optimistic updates, infinite queries, Suspense, and prefetching.
-- [Vue (Pinia)](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/vue-pinia-cursorrules-prompt-file.mdc) - Vue 3 state management with Pinia stores, Composition API usage, SSR, persistence, and testing.
+- [Vue (Pinia)](rules/vue-pinia-cursorrules-prompt-file.mdc) - Vue 3 state management with Pinia stores, Composition API usage, SSR, persistence, and testing.
 
 ### Database and API
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ By adding selected `.mdc` files to `.cursor/rules/`, you can use these rules dir
 - [React (MobX)](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/react-mobx-cursorrules-prompt-file.mdc) - React development with MobX integration.
 - [React (React Query)](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/react-query-cursorrules-prompt-file.mdc) - React development with React Query integration.
 - [React (TanStack Router + Query)](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/react-tanstack-router-query-cursorrules-prompt-file.mdc) - React SPAs combining TanStack Router v1 and TanStack Query v5 for zero-loading-spinner routing and type-safe server state.
+- [React (Zustand)](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/react-zustand-cursorrules-prompt-file.mdc) - React state management with Zustand stores, selectors, middleware, persistence, and testing.
 - [TanStack Query v5](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/tanstack-query-v5-cursorrules-prompt-file.mdc) - Query options, query key factories, mutations, optimistic updates, infinite queries, Suspense, and prefetching.
+- [Vue (Pinia)](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/vue-pinia-cursorrules-prompt-file.mdc) - Vue 3 state management with Pinia stores, Composition API usage, SSR, persistence, and testing.
 
 ### Database and API
 

--- a/rules/react-zustand-cursorrules-prompt-file.mdc
+++ b/rules/react-zustand-cursorrules-prompt-file.mdc
@@ -1,0 +1,115 @@
+---
+description: "React and TypeScript state management guidance for Zustand stores, selectors, middleware, persistence, and testing."
+globs: **/*.ts, **/*.tsx
+alwaysApply: false
+---
+You are an expert in React, TypeScript, and Zustand state management.
+
+# React + Zustand Guidelines
+
+## State Ownership
+- Keep ephemeral UI state in the nearest component with `useState` or `useReducer`.
+- Use URL state for shareable filters, pagination, tabs, and search params.
+- Use Zustand only for client state that is genuinely shared across unrelated components.
+- Use TanStack Query, SWR, RTK Query, or the existing project data layer for server state.
+- Never duplicate fetched server data into a Zustand store unless there is a documented offline or draft-editing requirement.
+
+## Store Design
+- Model each store as state plus named actions; avoid exposing anonymous setters for component code to misuse.
+- Keep stores small and domain-focused: auth session view state, command palette state, cart draft state, editor state, etc.
+- Split large stores into typed slices, then apply middleware only at the composed store boundary.
+- Keep derived values as selectors or small pure helpers unless they must be cached in state.
+- Store serializable data by default; keep DOM nodes, promises, sockets, and timers outside store state.
+
+```ts
+import { create } from 'zustand'
+
+interface SidebarState {
+  isOpen: boolean
+  activePanelId: string | null
+}
+
+interface SidebarActions {
+  openPanel: (panelId: string) => void
+  close: () => void
+  toggle: () => void
+}
+
+type SidebarStore = SidebarState & SidebarActions
+
+export const useSidebarStore = create<SidebarStore>()((set) => ({
+  isOpen: false,
+  activePanelId: null,
+  openPanel: (panelId) => set({ isOpen: true, activePanelId: panelId }),
+  close: () => set({ isOpen: false, activePanelId: null }),
+  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+}))
+```
+
+## Component Usage
+- Subscribe to the smallest possible slice: `useStore((state) => state.value)`.
+- Do not call a store hook without a selector in components unless the component truly needs every field.
+- Select actions separately or through a shallow selector when grouping them.
+- Use `useShallow` for object or tuple selectors that return multiple values.
+- Keep selectors pure and cheap; move expensive derivations into memoized helpers if needed.
+
+```tsx
+import { useShallow } from 'zustand/react/shallow'
+import { useSidebarStore } from '@/stores/sidebar-store'
+
+export function SidebarToggle() {
+  const { isOpen, toggle } = useSidebarStore(
+    useShallow((state) => ({
+      isOpen: state.isOpen,
+      toggle: state.toggle,
+    })),
+  )
+
+  return (
+    <button type="button" aria-expanded={isOpen} onClick={toggle}>
+      Toggle sidebar
+    </button>
+  )
+}
+```
+
+## TypeScript
+- Define explicit state and action interfaces for shared stores.
+- Avoid `any`; use `unknown` plus narrowing for external data.
+- Type action payloads and return values, including async actions.
+- Prefer discriminated unions for complex local status instead of several loosely related booleans.
+- Export store state types when tests, utilities, or vanilla store factories need them.
+
+## Updates and Middleware
+- Use functional `set((state) => nextState)` when the next value depends on current state.
+- Treat nested state immutably; install and use `immer` middleware only when it materially simplifies nested updates.
+- Use `persist` only for state that must survive reloads.
+- Use `partialize`, `version`, and `migrate` when persisting anything beyond trivial preferences.
+- Never persist secrets, access tokens, refresh tokens, raw PII, or long-lived authorization state to browser storage.
+- Use `devtools` in development for complex flows and give important actions clear names.
+- Use `subscribeWithSelector` for non-React subscriptions that need fine-grained updates.
+
+## Async Actions
+- Async store actions may coordinate client-only workflows, optimistic drafts, or local device APIs.
+- Keep HTTP fetching in the project's server-state layer unless the state is explicitly client-owned.
+- Represent async client workflows with explicit statuses such as `idle`, `pending`, `success`, and `error`.
+- Reset error state deliberately when retrying or closing a workflow.
+
+## SSR and React Server Components
+- Do not read or mutate browser-only stores from React Server Components.
+- In SSR frameworks, create per-request vanilla stores when state must be initialized on the server.
+- Guard persisted stores against hydration mismatches before rendering storage-backed values.
+- Keep store modules free of direct `window`, `document`, and storage access outside middleware configuration.
+
+## Testing
+- Test store actions directly without rendering React when possible.
+- Reset stores between tests with their initial state.
+- Assert selectors and actions separately from component behavior.
+- Mock server-state libraries instead of routing fetched data through Zustand for tests.
+
+## Anti-Patterns
+- Do not create one global store for the entire application.
+- Do not put form input state in Zustand unless multiple distant components edit the same draft.
+- Do not mutate nested objects directly without Immer middleware.
+- Do not use Zustand as an event bus; prefer explicit callbacks, services, or a scoped store.
+- Do not introduce Redux-style reducers, action constants, or dispatch wrappers unless the project already uses that pattern.

--- a/rules/vue-pinia-cursorrules-prompt-file.mdc
+++ b/rules/vue-pinia-cursorrules-prompt-file.mdc
@@ -1,0 +1,128 @@
+---
+description: "Vue 3 and TypeScript state management guidance for Pinia stores, Composition API usage, SSR, persistence, and testing."
+globs: **/*.ts, **/*.vue
+alwaysApply: false
+---
+You are an expert in Vue 3, TypeScript, and Pinia state management.
+
+# Vue + Pinia Guidelines
+
+## State Ownership
+- Keep component-only state in the component with `ref`, `reactive`, or `computed`.
+- Use Pinia for shared client state that spans routes, layouts, or unrelated component trees.
+- Use route params and query strings for shareable navigation state.
+- Use Nuxt `useFetch` / `useAsyncData`, TanStack Query for Vue, or the existing API layer for server state.
+- Do not copy server cache data into Pinia unless it is an intentional editable draft, offline cache, or workflow snapshot.
+
+## Store Structure
+- Prefer setup stores with `defineStore('name', () => { ... })` for Vue 3 Composition API projects.
+- Use one store file per domain under `stores/`, such as `stores/cart.ts` or `stores/session.ts`.
+- Keep state, computed getters, and actions together when they represent one cohesive domain.
+- Return every state property from setup stores so Pinia can track it for devtools, SSR, and plugins.
+- Keep getters pure and side-effect free; put writes, I/O, and orchestration in actions.
+
+```ts
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+
+interface CartLine {
+  id: string
+  name: string
+  quantity: number
+  unitPrice: number
+}
+
+export const useCartStore = defineStore('cart', () => {
+  const lines = ref<CartLine[]>([])
+
+  const itemCount = computed(() =>
+    lines.value.reduce((total, line) => total + line.quantity, 0),
+  )
+
+  function addLine(line: CartLine) {
+    const existing = lines.value.find((item) => item.id === line.id)
+    if (existing) {
+      existing.quantity += line.quantity
+      return
+    }
+    lines.value.push(line)
+  }
+
+  function clearCart() {
+    lines.value = []
+  }
+
+  return {
+    lines,
+    itemCount,
+    addLine,
+    clearCart,
+  }
+})
+```
+
+## Component Usage
+- Call stores at the top of `<script setup>` or inside setup functions, getters, and actions.
+- Use `storeToRefs()` when destructuring store state or getters in components.
+- Destructure actions directly when useful; actions remain bound to the store.
+- Avoid writing large business workflows in components; move them to store actions or composables.
+- Prefer computed values over watchers when deriving state.
+
+```vue
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useCartStore } from '@/stores/cart'
+
+const cart = useCartStore()
+const { itemCount } = storeToRefs(cart)
+const { clearCart } = cart
+</script>
+
+<template>
+  <button type="button" :disabled="itemCount === 0" @click="clearCart">
+    Clear cart
+  </button>
+</template>
+```
+
+## TypeScript
+- Type store state, action payloads, and API responses explicitly.
+- Avoid `any`; use `unknown` and narrow external inputs before committing them to state.
+- Use interfaces for object state that is shared across components or API boundaries.
+- Prefer discriminated unions for workflow status and error state.
+- Keep store IDs stable and descriptive because they appear in devtools and persistence keys.
+
+## Actions and Side Effects
+- Actions may be sync or async; keep each action focused on one user or domain workflow.
+- Validate action inputs at the boundary before mutating store state.
+- Represent async workflows with explicit `status`, `error`, and `lastUpdatedAt` fields when the UI depends on them.
+- Reset stale errors before retrying an async action.
+- Keep subscriptions, intervals, sockets, and browser listeners outside stores unless the store owns their lifecycle and cleanup.
+
+## SSR, Nuxt, and Router Guards
+- In SSR contexts, use the store inside setup, getters, or actions so Pinia can resolve the active app instance.
+- When using a store outside setup, such as in a router guard, pass the active Pinia instance if the framework requires it.
+- Do not read browser-only storage during server rendering.
+- In Nuxt, prefer the Nuxt Pinia integration and SSR-safe composables for data fetching.
+- Avoid singleton state leaks across requests by relying on the framework-created Pinia instance.
+
+## Persistence
+- Persist only the fields that must survive reloads, such as preferences or incomplete local drafts.
+- Never persist secrets, access tokens, refresh tokens, raw PII, or authorization decisions in browser storage.
+- Use field allowlists and versioned migrations for persisted store schemas.
+- Treat persisted state as untrusted input and validate it before using it for critical workflows.
+- Account for hydration timing before rendering UI that depends on persisted values.
+
+## Testing and Tooling
+- Use `@pinia/testing` for component tests that need stores.
+- Test store actions directly for domain behavior and edge cases.
+- Reset Pinia between tests to avoid shared state leakage.
+- Add HMR support with `acceptHMRUpdate()` in stores when the project uses Vite HMR patterns.
+- Keep stores easy to inspect in Vue Devtools by using clear state names and focused stores.
+
+## Anti-Patterns
+- Do not use Pinia as a dumping ground for every reactive value.
+- Do not destructure state directly from a store without `storeToRefs()`.
+- Do not mutate props or route objects through store actions.
+- Do not put server-only objects, request instances, DOM nodes, or timers in store state.
+- Do not create circular reads between stores in setup functions; compose stores through actions or computed values instead.


### PR DESCRIPTION
## Summary
- Add focused React Zustand cursor rules covering state ownership, selectors, middleware, persistence, SSR, and testing.
- Add focused Vue Pinia cursor rules covering store structure, Composition API usage, SSR, persistence, and testing.
- Add both entries to the State Management section of the README.

## Validation
- `pnpm test`
- `node scripts/check-repo-hygiene.mjs`
- `node scripts/check-repo-hygiene.mjs --changed-files /private/tmp/awesome-cursorrules.changed-files --diff-file /private/tmp/awesome-cursorrules.readme.diff`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded state management guidance with two new rule sets for React + Zustand and Vue + Pinia.
  * Updated README to surface the new state management entries.
  * Added comprehensive guidance covering store design, component integration, TypeScript practices, SSR/persistence considerations, testing tips, async/status modeling, and anti-patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->