### PR TITLE
Add cursor-rules-live to Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ By adding selected `.mdc` files to `.cursor/rules/`, you can use these rules dir
 
 - [CursorList](https://cursorlist.com)
 - [CursorDirectory](https://cursor.directory/)
+- [cursor-rules-live](https://github.com/linny006/cursor-rules-live) - Live, auto-updated index of public .cursorrules and cursorrules.json files on GitHub, refreshed every 15 minutes.
 
 ## How to Use
 


### PR DESCRIPTION
Adds [cursor-rules-live](https://github.com/linny006/cursor-rules-live) to the Directories section.

It's a live-updated index of public `.cursorrules` and `cursorrules.json` files on GitHub — refreshed every 15 minutes via a GitHub Actions cron pulling from GitHub Search. Currently indexes ~50 repositories at any time with metadata (language, stars, last updated).

Complements the existing CursorList and CursorDirectory entries by surfacing the long tail of in-repo `.cursorrules` files that aren't manually curated anywhere else.

- Open source, MIT licensed
- Repo: https://github.com/linny006/cursor-rules-live
- Live data: https://linny006.github.io/cursor-rules-live/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new directory entry linking to a live, auto-updated index of public cursor rules files available on GitHub.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PatrickJS/awesome-cursorrules/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->