### PR TITLE
Add React/Next.js, TypeScript, Python, Go production rules

### DIFF
--- a/rules/go-production/.cursorrules
+++ b/rules/go-production/.cursorrules
@@ -1,0 +1,9 @@
+.cursorrules — Go Production
+
+- Never ignore returned error with _. Handle or return every error.
+- Wrap with context: fmt.Errorf("functionName: %w", err).
+- Define interfaces at the consumer package. Keep interfaces to 1-2 methods.
+- ctx context.Context as first parameter in every I/O function.
+- Every goroutine has a clear owner and shutdown path. Use errgroup.
+- Always name struct fields. No positional initialization.
+- Table-driven tests with t.Run(tt.name, ...).

--- a/rules/python-fastapi-production/.cursorrules
+++ b/rules/python-fastapi-production/.cursorrules
@@ -1,0 +1,9 @@
+.cursorrules — Python Production
+
+- Every function signature must include type hints.
+- Never bare except: — catch specific exceptions or re-raise.
+- Pydantic BaseModel for API boundary data. @dataclass for internal structures.
+- Pass dependencies as parameters. No global variables in business logic.
+- Always pathlib.Path. / operator for path joining.
+- Never time.sleep() in async. Use asyncio.sleep().
+- Validate env vars at startup. No os.environ.get() silent defaults.

--- a/rules/python-fastapi-production/.cursorrules
+++ b/rules/python-fastapi-production/.cursorrules
@@ -1,4 +1,4 @@
-.cursorrules — Python Production
+.cursorrules — Python FastAPI Production
 
 - Every function signature must include type hints.
 - Never bare except: — catch specific exceptions or re-raise.

--- a/rules/react-nextjs-production/.cursorrules
+++ b/rules/react-nextjs-production/.cursorrules
@@ -1,0 +1,9 @@
+.cursorrules — React + Next.js App Router
+
+- Default to Server Components. Add "use client" only for hooks/browser APIs/event handlers.
+- Fetch data in Server Components. Never fetch in useEffect.
+- Use server actions for mutations, not client-side API route calls.
+- One component per file. File name = component name (PascalCase).
+- Define explicit interface Props. Never use any as prop type.
+- Every async route needs a sibling loading.tsx and error.tsx.
+- Use next/image instead of img. Use next/font instead of Google Fonts link tags.

--- a/rules/typescript-strict-production/.cursorrules
+++ b/rules/typescript-strict-production/.cursorrules
@@ -1,0 +1,9 @@
+.cursorrules — TypeScript Strict Mode
+
+- tsconfig.json must have "strict": true. Never disable strict checks.
+- No any. Use unknown + type guards, or as Type only at I/O boundaries.
+- Every exported function needs explicit return type including async (Promise<T>).
+- Model state as discriminated unions: { status: "loading" } | { status: "success"; data: T }.
+- Readonly<T> for immutable data. as const for config objects.
+- Validate env vars at startup. Never process.env.FOO in business logic.
+- No TypeScript enum. Use const object + typeof union.


### PR DESCRIPTION
## Production-tested rules for 4 common stacks

Adding `.cursorrules` files for 4 stacks based on the most common AI code generation failure modes:

- **React + Next.js App Router** — Server vs Client boundary, data fetching, error states
- **TypeScript strict mode** — no-any enforcement, discriminated unions, typed env vars
- **Python production** — type hints, error handling, Pydantic, dependency injection
- **Go production** — error wrapping, interface placement, context propagation, goroutine ownership

Each rule targets the specific pattern AI generates incorrectly for that stack — not generic best practices.

These files follow the existing `.cursorrules` format in this repo. There's also an `.mdc` version available for Cursor agent mode (which uses a different format): [cursor-mdc-rules](https://github.com/oliviacraft/cursor-mdc-rules)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Go production guidelines for error handling, context-first I/O, interface sizing, goroutine lifecycle, struct field naming, and table-driven tests.
  * Added Python/FastAPI standards: typed signatures, no bare excepts, Pydantic at API boundaries, DI-by-parameter, async-safe patterns, and env validation on startup.
  * Added React/Next.js App Router conventions for Server/Client usage, data fetching, routing, and component structure.
  * Added TypeScript strict-mode checklist: strict config, no any, explicit exports, immutability patterns, and startup env validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->