### PR TITLE
Add AI coding agent baseline rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ By adding selected `.mdc` files to `.cursor/rules/`, you can use these rules dir
 ### Build Tools and Development
 
 - [AI Agent Specialist](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/ai-agent-specialist.mdc) - TypeScript, React, Node.js, clean architecture, testing, and WHY-oriented engineering guidance.
+- [AI Coding Agent Baseline](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/ai-coding-agent-baseline.mdc) - Small operating layer for Cursor Agent and companion AI coding tools: read local code, keep edits scoped, preserve user changes, and verify before handoff.
 - [Alpha Skills](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/alpha-skills-quant-factor-research.mdc) - Quantitative factor research skills for Cursor. Evaluate factors, run backtests, mine new alpha through natural language.
 - [Anti-Over-Engineering](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/anti-overengineering.mdc) - Keeping changes scoped, simple, and directly tied to the user's request.
 - [Anti-Sycophancy Code Discipline](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/anti-sycophancy-code-discipline-cursorrules-prompt-file.mdc) - 17 directives blocking the most common LLM coding honesty failures: hallucinated APIs, invented signatures, false-confidence validation, manufactured-urgency capitulation, authority-driven softening, and self-referential comments. Drop the `.mdc` in `.cursor/rules/`.

--- a/rules/ai-coding-agent-baseline.mdc
+++ b/rules/ai-coding-agent-baseline.mdc
@@ -1,0 +1,48 @@
+---
+description: "Baseline project rule for AI coding agents: read local code, keep edits scoped, preserve user changes, and verify before handoff."
+globs: **/*
+alwaysApply: true
+---
+# AI Coding Agent Baseline
+
+Use this rule as a small operating layer for Cursor Agent and other AI coding tools.
+
+Source repo and companion AGENTS.md / CLAUDE.md sample:
+https://github.com/758302-tech/agent-rules-starter-free
+
+Full multi-tool pack:
+https://boltonmejia.gumroad.com/l/agent-rules-starter-pack
+
+## Before Editing
+
+- Read the relevant files before proposing or changing code.
+- Prefer existing patterns, utilities, dependencies, and naming conventions.
+- Identify whether the task is a bug fix, feature, refactor, content edit, test, or release task.
+- If the task is ambiguous, make the safest reasonable assumption and state it briefly.
+
+## Editing Rules
+
+- Keep changes scoped to the user's request.
+- Do not rewrite unrelated files.
+- Do not change public behavior unless the request requires it.
+- Do not introduce a new dependency unless it clearly reduces complexity.
+- Add comments only where they explain non-obvious logic.
+- Avoid broad refactors during narrow fixes.
+
+## Testing
+
+- Run the smallest meaningful verification command available.
+- If tests cannot run, explain why and name the risk.
+- For UI work, verify that text fits, controls are usable, and the first screen is the real experience.
+
+## Git Safety
+
+- Never discard user changes.
+- Never run destructive git commands unless explicitly requested.
+- Before committing, summarize changed files and verification.
+
+## Final Response
+
+- Lead with what changed.
+- Include verification results.
+- Mention any remaining risk or manual step.


### PR DESCRIPTION
## Summary
- Add a small AI Coding Agent Baseline Cursor Project Rule
- Link the README entry under Build Tools and Development
- Include the companion free sample repo for AGENTS.md and CLAUDE.md users

## Why
This rule gives Cursor Agent a lightweight, reusable operating layer for reading local code first, keeping edits scoped, preserving user changes, and running focused verification before handoff.

## Validation
- Checked the new rule frontmatter includes description, globs, and alwaysApply.
- Checked the README link and rule slug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added comprehensive guidelines for AI coding agent workflows, including code modification practices, verification procedures, and safety protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->