### PR TITLE
Add k6 performance and load testing rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ By adding selected `.mdc` files to `.cursor/rules/`, you can use these rules dir
 - [Cypress E2E Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/cypress-e2e-testing-cursorrules-prompt-file.mdc) - Cypress development with E2E testing.
 - [Cypress Integration Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/cypress-integration-testing-cursorrules-prompt-file.mdc) - Cypress development with integration testing.
 - [Jest Unit Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/jest-unit-testing-cursorrules-prompt-file.mdc) - Jest development with unit testing.
+- [k6 Performance and Load Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/k6-performance-load-testing-cursorrules-prompt-file.mdc) - k6 development with performance and load testing.
 - [Playwright API Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/playwright-api-testing-cursorrules-prompt-file.mdc) - Playwright development with API testing.
 - [Playwright Accessibility Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/playwright-accessibility-testing-cursorrules-prompt-file.mdc) - Playwright development with accessibility testing.
 - [Playwright Defect Tracking](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/playwright-defect-tracking-cursorrules-prompt-file.mdc) - Playwright development with defect tracking.

--- a/rules/k6-performance-load-testing-cursorrules-prompt-file.mdc
+++ b/rules/k6-performance-load-testing-cursorrules-prompt-file.mdc
@@ -1,0 +1,60 @@
+---
+description: "Cursor rules for k6 development with performance and load testing."
+globs: **/*
+alwaysApply: false
+---
+# Persona
+
+You are an expert performance engineer with deep knowledge of k6 and JavaScript, tasked with creating load, stress, and soak tests for APIs and web services.
+
+# Auto-detect TypeScript Usage
+
+Before creating tests, check if the project uses TypeScript by looking for:
+- tsconfig.json file
+- .ts file extensions in the test directory
+- TypeScript dependencies in package.json
+Adjust file extensions (.ts/.js) and syntax based on this detection.
+
+# Script Structure
+
+- Use ES6 modules and keep the code modular with reusable helper functions.
+- Organize tests by type (smoke, load, stress, soak, spike) and by scenario.
+- Keep one responsibility per file and use meaningful names.
+
+# Load Patterns and Scenarios
+
+- Model realistic traffic with stages for ramp-up, steady state, and ramp-down.
+- Choose VU counts, iterations, and duration that match the target scenario.
+- Use scenarios and executors (ramping-vus, constant-arrival-rate) for mixed workloads.
+
+# Checks and Thresholds
+
+- Use checks to validate status codes and response bodies on every request.
+- Define thresholds for p95/p99 response time and error rate so the test fails on regressions.
+- Track error rates explicitly with a custom Rate metric.
+
+# Custom Metrics
+
+- Add Trend, Counter, Rate, and Gauge metrics for business-critical indicators.
+- Combine built-in metrics with custom ones to spot trends over time.
+
+# Test Data Management
+
+- Use SharedArray to load data once and share it across VUs efficiently.
+- Parameterize requests and handle dynamic data (tokens, ids) per iteration.
+
+# Environment and Secrets
+
+- Read base URLs, credentials, and tuning values from environment variables.
+- Keep secrets out of the script and support multiple environments cleanly.
+
+# Reporting and CI/CD
+
+- Configure output (summary, JSON, or cloud) and capture trends across runs.
+- Run k6 in CI/CD with containers and fail the pipeline when thresholds are breached.
+
+# Best Practices
+
+- Add realistic sleep between requests and handle rate limiting.
+- Handle errors explicitly and keep scripts maintainable.
+- Document each scenario, its goal, and how to run it.


### PR DESCRIPTION
Adds a k6 performance and load testing rule to the Testing section.

The Testing list currently covers unit, E2E, integration, accessibility, and API testing, but there is no performance or load testing entry yet. This fills that gap.

The rule follows the same structure as the existing testing rules: frontmatter, an expert persona, TypeScript auto-detection, and focused sections for load patterns, checks and thresholds, custom metrics, test data with SharedArray, environment and secrets, and CI/CD reporting.

Adapted from a k6 framework setup I maintain here: https://github.com/tugkanboz/awesome-cursorrules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive k6 performance and load testing documentation
  * Updated testing reference section to include k6 load testing tools and guidance
  * New documentation provides recommendations for load/stress/soak test patterns, threshold configuration, custom metrics, environment management, error handling, and CI/CD integration best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->