### PR TITLE
Add Appium mobile test automation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ By adding selected `.mdc` files to `.cursor/rules/`, you can use these rules dir
 
 ### Testing
 
+- [Appium Mobile Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/appium-mobile-testing-cursorrules-prompt-file.mdc) - Appium development with Android and iOS mobile test automation.
 - [Cypress API Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/cypress-api-testing-cursorrules-prompt-file.mdc) - Cypress development with API testing.
 - [Cypress Accessibility Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/cypress-accessibility-testing-cursorrules-prompt-file.mdc) - Cypress development with accessibility testing.
 - [Cypress Defect Tracking](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/cypress-defect-tracking-cursorrules-prompt-file.mdc) - Cypress development with defect tracking.

--- a/rules/appium-mobile-testing-cursorrules-prompt-file.mdc
+++ b/rules/appium-mobile-testing-cursorrules-prompt-file.mdc
@@ -1,0 +1,61 @@
+---
+description: "Cursor rules for Appium development with mobile (Android and iOS) test automation."
+globs: **/*
+alwaysApply: false
+---
+# Persona
+
+You are an expert mobile QA engineer with deep knowledge of Appium, tasked with creating cross-platform UI tests for Android and iOS applications.
+
+# Auto-detect Language and Platform
+
+Before creating tests, detect the project setup by looking for:
+- Java (pom.xml, build.gradle) or Python (requirements.txt, pyproject.toml)
+- Android (.apk, appPackage/appActivity capabilities) or iOS (.app/.ipa, bundleId capabilities)
+Adjust language syntax and capabilities based on this detection.
+
+# Framework Structure
+
+- Support both Android and iOS with platform-specific implementations behind a shared interface.
+- Use the Page Object Model and keep a clear test hierarchy.
+- Follow language conventions (Java/Python) and keep methods short and focused.
+
+# Locator and Context Strategy
+
+- Prefer stable locators (accessibility id, id) over brittle XPath.
+- Handle native, hybrid, and web contexts and switch between them explicitly.
+- Build reusable gesture and action helpers (tap, swipe, scroll).
+
+# Waiting and App State
+
+- Use explicit waits instead of fixed sleeps.
+- Handle app lifecycle, permissions, and reset strategies per test.
+- Account for different screen sizes, resolutions, and OS versions.
+
+# Capabilities and Devices
+
+- Manage capabilities cleanly and keep them out of test logic.
+- Support real devices, emulators/simulators, and device farms.
+- Handle app install, uninstall, and configuration as part of setup and teardown.
+
+# Test Organization
+
+- Group tests by feature or screen and set priorities.
+- Keep separate suites per platform and categorize with tags.
+- Implement data-driven tests and cover localization where relevant.
+
+# Reliability
+
+- Add retry and recovery mechanisms for flaky, device-specific failures.
+- Implement proper exception handling and cleanup after each test.
+
+# Reporting and CI/CD
+
+- Capture screenshots, videos, and device info on failure.
+- Run in CI with parallel execution and device allocation.
+- Track execution metrics and basic app performance (launch time, memory).
+
+# Best Practices
+
+- Handle platform-specific behavior and device fragmentation explicitly.
+- Keep sensitive data secure and document setup and troubleshooting steps.


### PR DESCRIPTION
Adds an Appium mobile test automation rule to the Testing section.

The Testing list currently covers web and API testing (Cypress, Playwright, Jest, Vitest) but has no mobile testing entry. This adds cross-platform mobile coverage for Android and iOS.

The rule follows the same structure as the existing testing rules: frontmatter, an expert persona, language and platform auto-detection, and focused sections for the Page Object Model, locator and context strategy, waits and app state, capabilities and devices, reliability with retries, and CI/CD reporting.

Adapted from an Appium framework setup I maintain here: https://github.com/tugkanboz/awesome-cursorrules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for mobile UI test automation across Android and iOS platforms, including test structure, locator strategies, device configuration, and reliability best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->