### PR TITLE
Add VibeRaven production readiness gate rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ By adding selected `.mdc` files to `.cursor/rules/`, you can use these rules dir
 - [Cloudflare Email to Telegram](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/cloudflare-email-telegram-cursorrules-prompt-file.mdc) - Setting up email-to-Telegram forwarding via Cloudflare Email Routing and Workers using the mail2tg CLI.
 - [Netlify](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/netlify-official-cursorrules-prompt-file.mdc) - Official deployment platform integration.
 - [Vercel](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/vercel-deployment-cursorrules-prompt-file.mdc) - Deployment with serverless functions, Edge Runtime, middleware, caching, CI/CD, and production-ready configuration.
+- [VibeRaven Production-Readiness Gate](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/viberaven-production-readiness-gate.mdc) - Production-readiness gate for AI-built apps before launch, deploy, auth, billing, database, RLS, env vars, webhooks, monitoring, or tests.
 
 ### Build Tools and Development
 

--- a/rules/viberaven-production-readiness-gate.mdc
+++ b/rules/viberaven-production-readiness-gate.mdc
@@ -1,7 +1,7 @@
 ---
 description: "Production-readiness gate for AI-built apps using VibeRaven before launch, deploy, auth, billing, database, RLS, env vars, webhooks, monitoring, or tests."
 globs: **/*
-alwaysApply: false
+alwaysApply: true
 ---
 # VibeRaven Production-Readiness Gate
 
@@ -17,13 +17,15 @@ Before claiming an app is production ready, run:
 npx -y viberaven --agent-mode
 ```
 
-Then read these files before making more changes:
+Then read these primary gate artifacts before making more changes:
 
 - `.viberaven/agent-tasklist.md`
 - `.viberaven/gate-result.json`
 - `.viberaven/context-map.json`
-- `.viberaven/agent-summary.md`
-- `.viberaven/launch-playbook.md`
+
+If present, use `.viberaven/agent-summary.md` and
+`.viberaven/launch-playbook.md` as supporting context, but treat
+`.viberaven/gate-result.json` as the machine verdict.
 
 Do not deploy or push after auth, RLS, billing, webhook, environment, or provider
 configuration changes until `gate.status` is `clear` in
@@ -57,6 +59,7 @@ exact step to the user, wait for confirmation, then verify again.
 npx -y viberaven next --json
 npx -y viberaven prompt --gap <gap-id>
 npx -y viberaven --heal --plan --gap <gap-id>
+npx -y viberaven --heal --apply --gap <gap-id> --yes
 npx -y viberaven --strict
 npx -y viberaven audit --vercel-supabase
 ```

--- a/rules/viberaven-production-readiness-gate.mdc
+++ b/rules/viberaven-production-readiness-gate.mdc
@@ -1,0 +1,62 @@
+---
+description: "Production-readiness gate for AI-built apps using VibeRaven before launch, deploy, auth, billing, database, RLS, env vars, webhooks, monitoring, or tests."
+globs: **/*
+alwaysApply: false
+---
+# VibeRaven Production-Readiness Gate
+
+Use this rule when preparing an AI-built app for launch, deployment, real users,
+auth, billing, database changes, Supabase RLS, environment variables, webhooks,
+monitoring, rate limits, or tests.
+
+## Required Gate
+
+Before claiming an app is production ready, run:
+
+```bash
+npx -y viberaven --agent-mode
+```
+
+Then read these files before making more changes:
+
+- `.viberaven/agent-tasklist.md`
+- `.viberaven/gate-result.json`
+- `.viberaven/context-map.json`
+- `.viberaven/agent-summary.md`
+- `.viberaven/launch-playbook.md`
+
+Do not deploy or push after auth, RLS, billing, webhook, environment, or provider
+configuration changes until `gate.status` is `clear` in
+`.viberaven/gate-result.json`.
+
+## Agent Loop
+
+1. Run `npx -y viberaven --agent-mode` from the project root.
+2. Read `.viberaven/agent-tasklist.md` completely.
+3. Fix one listed repo-code launch gap.
+4. Run `npx -y viberaven --verify`.
+5. Repeat until `.viberaven/gate-result.json` reports `gate.status: "clear"`.
+
+If the scan output prints `VIBERAVEN_NEXT_ACTION`, follow its `batchSize`,
+`scanNow`, and `stalled` values. Do not verify after every patch; batch supported
+repo-code fixes and verify once per loop.
+
+## Provider Work
+
+Provider dashboard work is not fixed by repo edits. Billing setup, DNS, webhook
+registration, credentials, quotas, and live provider verification must be
+completed in the provider dashboard or verified through read-only provider
+evidence.
+
+If VibeRaven prints `VIBERAVEN_PROVIDER_ACTION`, present the dashboard URL and
+exact step to the user, wait for confirmation, then verify again.
+
+## Useful Commands
+
+```bash
+npx -y viberaven next --json
+npx -y viberaven prompt --gap <gap-id>
+npx -y viberaven --heal --plan --gap <gap-id>
+npx -y viberaven --strict
+npx -y viberaven audit --vercel-supabase
+```


### PR DESCRIPTION
## Summary

Adds a reusable Cursor rule for running VibeRaven as a production-readiness gate before launch, deployment, auth, billing, database/RLS, env var, webhook, monitoring, or test-sensitive work.

The rule tells Cursor/agents to run `npx -y viberaven --agent-mode`, read the generated gate artifacts, fix one listed launch gap at a time, and avoid treating provider dashboard tasks as complete from repo edits alone.

## Contribution Type

- [x] New Cursor rule file or rules folder
- [ ] Update/fix to an existing rule
- [x] New `rules/*.mdc` rule
- [x] Documentation or README cleanup

## Value To Cursor Users

This gives Cursor users a concrete pre-launch workflow for AI-built apps instead of a vague "make this production ready" prompt. It focuses the agent on repo evidence, `.viberaven/gate-result.json`, one-gap-at-a-time fixes, and provider-dashboard handoff steps for common production risks such as Supabase RLS, Vercel env drift, auth redirects, webhooks, billing, and monitoring.

## Added Or Changed Files

- `rules/viberaven-production-readiness-gate.mdc` - new universal production-readiness gate rule with verified VibeRaven artifacts and CLI commands.
- `README.md` - adds the rule to the Hosting and Deployments section.

## Quality Checklist

- [x] The contribution includes original rule content, or clearly credits the source.
- [x] New rule files use a descriptive kebab-case filename, such as `react-typescript.mdc`.
- [x] New `rules/*.mdc` files include frontmatter with a non-empty `description`, relevant `globs`, and `alwaysApply: false` unless the rule is universal.
- [x] README links use canonical GitHub URLs for repo files and point to the correct category.
- [x] The text is neutral and useful, not sales copy.
- [x] This is not a standalone external tool, product, directory, marketplace, or service listing.
- [x] No secrets, tokens, affiliate links, tracking links, or unrelated product claims are included.
- [x] I checked for duplicate or near-duplicate existing entries.

## Notes For Maintainers

`alwaysApply: true` is intentional here because this is a universal pre-launch safety rule, not a framework-specific style rule. The command list was checked against `npx -y viberaven@latest --help` and the rule now distinguishes the primary generated artifacts from optional supporting summaries/playbooks.

Validation run locally:

- `node scripts/check-repo-hygiene.mjs --only readme`
- `node scripts/check-repo-hygiene.mjs --only rules`
- `node scripts/check-awesome-list.mjs`