### PR TITLE
Add DOS Verify Done-Claims rule (gate agent done-claims on git ground truth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ By adding selected `.mdc` files to `.cursor/rules/`, you can use these rules dir
 - [Cypress Defect Tracking](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/cypress-defect-tracking-cursorrules-prompt-file.mdc) - Cypress development with defect tracking.
 - [Cypress E2E Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/cypress-e2e-testing-cursorrules-prompt-file.mdc) - Cypress development with E2E testing.
 - [Cypress Integration Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/cypress-integration-testing-cursorrules-prompt-file.mdc) - Cypress development with integration testing.
+- [DOS Verify Done-Claims](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/dos-verify-done-claims-cursorrules-prompt-file.mdc) - Gate AI done/shipped/fixed claims on git ground truth via the DOS kernel (dos verify, dos commit-audit) instead of the agent's own narration.
 - [Jest Unit Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/jest-unit-testing-cursorrules-prompt-file.mdc) - Jest development with unit testing.
 - [Playwright API Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/playwright-api-testing-cursorrules-prompt-file.mdc) - Playwright development with API testing.
 - [Playwright Accessibility Testing](https://github.com/PatrickJS/awesome-cursorrules/blob/main/rules/playwright-accessibility-testing-cursorrules-prompt-file.mdc) - Playwright development with accessibility testing.

--- a/rules/dos-verify-done-claims-cursorrules-prompt-file.mdc
+++ b/rules/dos-verify-done-claims-cursorrules-prompt-file.mdc
@@ -1,0 +1,36 @@
+---
+description: "Gate AI done/shipped/fixed claims on ground truth from the DOS kernel (dos verify, dos commit-audit) — git ancestry and the commit's own diff, never the agent's own narration."
+globs: **/*
+alwaysApply: false
+---
+You verify your own "done" claims against ground truth before reporting work as complete.
+
+When you say a task is "done", "shipped", "fixed", or "passing", that is a claim — not a fact. A claim you check by re-reading your own work is *consistency, not grounding*. Confirm the claimed effect from a witness you did not author: git ancestry and the commit's actual diff, via the deterministic DOS kernel (`dos verify`, `dos commit-audit`). DOS needs no API key, no LLM, and no network.
+
+## Setup
+
+- Install once: `pip install dos-kernel` (the PyPI name is `dos-kernel`, NOT the bare `dos`, which is an unrelated package).
+- All DOS verbs below are read-only: they read git history and the working tree; they never mutate the repo, push, or reach the network.
+
+## Before reporting any commit as done
+
+- Run `dos commit-audit --workspace . HEAD`.
+  > WHY: A commit subject is forgeable (whoever wrote the message authored it); the files it touched are not (git did). This grades whether the subject matches what the diff actually did.
+- The exit code IS the verdict: `0` = the diff backs the claim's kind, `1` = an unwitnessed claim (the message says more than the diff did), `2` = unreadable ref.
+- On exit `1` (CLAIM_UNWITNESSED): do NOT report the work as done. Show the commit, explain the gap, and fix it — a `fix:` that only touched a README, or a "tests pass" that deleted the assertions, lands here.
+
+## Before closing a ticket or claiming a phase shipped
+
+- Run `dos verify --workspace . PLAN PHASE` (substitute the plan/phase ids the work claims to complete).
+  > WHY: This answers did-it-ship from git history, not from the transcript.
+- `shipped: true` with `source: registry` or `source: grep` is real evidence — safe to close.
+- `shipped: false` / `source: none` means there is no positive evidence. Treat that as "not shipped" and keep the ticket open; it is an honest "no evidence", not a tool failure.
+
+## Boundaries
+
+- This checks did-the-claimed-thing-actually-ship — NOT whether the code is correct.
+  > WHY: Correctness is the test suite's job. Run the tests as a separate gate; `dos commit-audit` grades the *kind* of change, never its correctness.
+- In a repo with no commits there is nothing to witness; `dos verify` will honestly report `source: none`.
+- Never accept a "done" because your own prose was confident. The verdict from evidence you did not author overrides your narration.
+
+> Adapted from the DOS reference witness-claim discipline (https://github.com/anthony-chaudhary/dos-kernel). DOS is the domain-free trust substrate for AI agents: the part that doesn't believe the agent's self-report.


### PR DESCRIPTION
## What

Adds `rules/dos-verify-done-claims-cursorrules-prompt-file.mdc` (and a Testing-section README entry) — a Cursor Project Rule that gates an AI agent's "done / shipped / fixed" claim on **ground truth** instead of the agent's own narration, using the deterministic [DOS kernel](https://github.com/anthony-chaudhary/dos-kernel) (`dos verify`, `dos commit-audit`).

## Why

When an agent says "done", that is a claim, not a fact — and a claim it checks by re-reading its own work is consistency, not grounding. A commit subject is forgeable (whoever wrote the message authored it); the files it touched are not (git did). This rule has Cursor confirm the claimed effect from git ancestry and the commit's actual diff before reporting work complete — catching a `fix:` that only touched a README, or a "tests pass" that deleted the assertions. It complements the existing PR Review / QA rules in the Testing section.

## Format

- Modern Cursor Project Rules `.mdc` with `description` / `globs: **/*` / `alwaysApply: false` frontmatter, matching the repository's format.
- README entry added to `### Testing`, alphabetically placed and following the existing link style.
- The rule documents its boundaries: it checks did-the-claimed-thing-ship, **not** correctness (that is the test suite's job), and notes the `dos` verbs are read-only and `pip install dos-kernel` is the install (the PyPI name is `dos-kernel`, not the unrelated `dos`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new testing guidance for verifying completion claims against ground truth, ensuring reliable reporting of work status.
  * Updated testing section with reference to a verification mechanism that validates done/shipped/fixed claims through deterministic validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->