### PR TITLE
feat: add Nika workflow language rule (.nika.yaml authoring)

### DIFF
--- a/rules/nika-workflow-language.mdc
+++ b/rules/nika-workflow-language.mdc
@@ -1,0 +1,24 @@
+---
+description: Nika workflow language rules for AI assistance
+globs: ["**/*.nika.yaml", "**/*.nika.yml"]
+alwaysApply: false
+---
+
+# Nika Workflow Language
+
+Envelope: `nika: v1` (always · frozen forever). Extension: `.nika.yaml`.
+
+## 4 Verbs (locked forever)
+- `infer:` LLM call (`prompt`, `system?`, `temperature?`, `schema?`)
+- `exec:` subprocess (`command`, `cwd?`, `capture: text|structured`)
+- `invoke:` builtin/MCP tool (`tool`, `args`) — HTTP fetch = `tool: nika:fetch` (a tool, not a verb)
+- `agent:` multi-turn loop (`prompt`, `tools`, `max_turns`, `max_tokens_total`)
+
+## Authoring Discipline
+- Interpolation uses `${{ vars.x }}` · `${{ tasks.id.output }}` · `${{ env.KEY }}` · `${{ with.alias }}`.
+- Bindings use `with: { alias: ${{ tasks.id.output }} }` then `${{ with.alias }}`.
+- Models use the combined form `provider/name` (for example `mock/echo`, `ollama/qwen3.5:4b`, `mistral/mistral-small`).
+- `depends_on` is always an array: `depends_on: [task_id]`.
+- Secrets come from the environment — never inline literal keys.
+- After every edit, run `nika check <file>` and repair from diagnostics.
+- Unknown code? Run `nika explain NIKA-XXXX`.

--- a/rules/nika-workflow-language.mdc
+++ b/rules/nika-workflow-language.mdc
@@ -6,10 +6,10 @@ alwaysApply: false
 
 # Nika Workflow Language
 
-Envelope: `nika: v1` (always · frozen forever). Extension: `.nika.yaml`.
+Envelope: `nika: v1` (always · frozen forever). Extensions: `.nika.yaml` (canonical) and `.nika.yml`.
 
 ## 4 Verbs (locked forever)
-- `infer:` LLM call (`prompt`, `system?`, `temperature?`, `schema?`)
+- `infer:` LLM call (`prompt`, `system?`, `temperature?`, `schema?`, `max_tokens?`, `model?`)
 - `exec:` subprocess (`command`, `cwd?`, `capture: text|structured`)
 - `invoke:` builtin/MCP tool (`tool`, `args`) — HTTP fetch = `tool: nika:fetch` (a tool, not a verb)
 - `agent:` multi-turn loop (`prompt`, `tools`, `max_turns`, `max_tokens_total`)
@@ -19,6 +19,6 @@ Envelope: `nika: v1` (always · frozen forever). Extension: `.nika.yaml`.
 - Bindings use `with: { alias: ${{ tasks.id.output }} }` then `${{ with.alias }}`.
 - Models use the combined form `provider/name` (for example `mock/echo`, `ollama/qwen3.5:4b`, `mistral/mistral-small`).
 - `depends_on` is always an array: `depends_on: [task_id]`.
-- Secrets come from the environment — never inline literal keys.
+- Secrets are declared in a top-level `secrets:` block (e.g. `source: env`, `key: MY_KEY`) and referenced as `${{ secrets.name }}` — never inline literal keys; `${{ env.* }}` is for non-sensitive configuration.
 - After every edit, run `nika check <file>` and repair from diagnostics.
 - Unknown code? Run `nika explain NIKA-XXXX`.


### PR DESCRIPTION
Adds a rule for the **Nika workflow language** (`.nika.yaml` files — AI workflows as reviewable DAGs).

The rule teaches Cursor the envelope, the four verbs, the interpolation/binding forms, and the authoring discipline (run `nika check` after every edit, repair from diagnostics). Scoped by globs to `**/*.nika.yaml` only, `alwaysApply: false`.

Provenance note: this is exactly the rule the `nika init` command generates (engine v0.99.0) — contributed here so Cursor users get it without installing anything first. I'll refresh it if the language surface ever changes (the envelope and verbs are frozen).

Disclosure: I'm the author of Nika (AGPL-3.0 Rust engine).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added authoring guidance for Nika workflow files.
  * Documented supported workflow verbs, syntax conventions, bindings, model naming format, and dependency declarations.
  * Added secret handling rules (including prohibited inline literal secret keys) and required reference format.
  * Included validation and troubleshooting guidance using the appropriate Nika commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->