### PR TITLE
feat(rules): add Claude Agent Studio multi-agent rules

### DIFF
--- a/rules/claude-agent-studio-rules.mdc
+++ b/rules/claude-agent-studio-rules.mdc
@@ -1,6 +1,6 @@
 ---
 description: "Production multi-agent engineering rules, zero-trust client privacy patterns, and deterministic coding guardrails generated via DevScratchpad AI Skill Studio"
-globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
+globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mts", "**/*.cts", "**/*.mjs", "**/*.cjs"]
 alwaysApply: false
 ---
 You are an expert software engineer adhering to strict deterministic coding standards, zero-trust client architecture, and multi-agent coordination principles.

--- a/rules/claude-agent-studio-rules.mdc
+++ b/rules/claude-agent-studio-rules.mdc
@@ -1,0 +1,25 @@
+---
+description: "Production multi-agent engineering rules, zero-trust client privacy patterns, and deterministic coding guardrails generated via DevScratchpad AI Skill Studio"
+globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
+alwaysApply: false
+---
+You are an expert software engineer adhering to strict deterministic coding standards, zero-trust client architecture, and multi-agent coordination principles.
+
+> Rule generator & interactive studio: [DevScratchpad AI Skill Studio](https://www.devscratchpad.tech/ai-skill-studio)
+
+## Core Principles
+
+1. **Zero-Trust Privacy & Local Isolation**
+   - Ensure sensitive payloads, tokens, passwords, and user inputs never transmit to unverified third-party endpoints.
+   - Use browser-native APIs (`WebCrypto`, `SubtleCrypto`, `Blob`, `IndexedDB`) for local-first operations.
+   - Guard client-only state against hydration mismatches (`if (!isMounted) return null`).
+
+2. **TypeScript & Type Safety Invariants**
+   - Always prefer strict TypeScript definitions over `any` or loose casts.
+   - Validate runtime boundaries with runtime schemas (Zod, TypeBox, or AJV).
+   - Discourage mutable global state; use pure functions and deterministic reducers.
+
+3. **Deterministic Multi-Agent Coordination**
+   - Separate concerns across agent roles: Planner, Coder, Auditor, and Validator.
+   - Maintain immutable verification records: test outputs, typecheck logs, and static analysis artifacts.
+   - Eliminate circular dependencies and self-referential linking in programmatic page matrices.


### PR DESCRIPTION
## Summary
Adds production multi-agent engineering rules (`rules/claude-agent-studio-rules.mdc`) for Cursor IDE, enforcing zero-trust client privacy patterns, strict TypeScript invariants, and deterministic multi-agent coding guardrails.

## Contribution Type
- [x] New Cursor Rule (`.mdc`)
- [ ] Documentation / Directory Update

## Value To Cursor Users
Provides modular, context-efficient guardrails for multi-agent workflows, local-first browser operations, and type safety invariants without context window bloat. Generated with [DevScratchpad AI Skill Studio](https://www.devscratchpad.tech/ai-skill-studio).

## Added Or Changed Files
- `rules/claude-agent-studio-rules.mdc`: Modular Cursor project rule with comprehensive globs (`**/*.ts`, `**/*.tsx`, `**/*.js`, `**/*.jsx`, `**/*.mts`, `**/*.cts`, `**/*.mjs`, `**/*.cjs`).

## Recent Updates
- Supports full 5-Layer AI Agent Suite (`.cursorignore`, `.claudeignore`, `llms.txt`, `ARCHITECTURE.md`).
- Terminal CLI scaffolding enabled via `npx devscratchpad init`.

## Quality Checklist
- [x] `.mdc` YAML frontmatter is valid with `description` and `globs`
- [x] Expanded module extensions to include `.mts`, `.cts`, `.mjs`, and `.cjs` per CodeRabbit automated check
- [x] Includes practical, non-hallucinatory engineering guardrails
- [x] Follows repository contribution guidelines